### PR TITLE
docs: add cross-platform build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Calibration Library
 
-[![Build Status](https://github.com/VitalyVorobyev/calibration/actions/workflows/build.yml/badge.svg)](https://github.com/VitalyVorobyev/calibration/actions/workflows/build.yml)
+[![Build Status](https://github.com/VitalyVorobyev/calibration/actions/workflows/ci.yml/badge.svg)](https://github.com/VitalyVorobyev/calibration/actions/workflows/ci.yml)
 
 A C++ library for camera calibration and vision-related geometric transformations.
 
@@ -17,31 +17,75 @@ A C++ library for camera calibration and vision-related geometric transformation
 - Eigen3: Linear algebra library
 - Ceres: Non-linear optimization
 - nlohmann-json: JSON parsing and serialization
-
-## Installation
-
-### Ubuntu
-
-```bash
-sudo apt install libeigen3-dev libceres-dev nlohmann-json3-dev
-```
-
-### Other platforms
-
-For other platforms, please install the equivalent dependencies using your system's package manager.
+- CMake and Ninja build system
 
 ## Build
 
+### Linux and macOS
+
+Install the build dependencies using your system package manager.
+
+#### Ubuntu
+
 ```bash
-mkdir build && cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="../install" ..
-cmake --build . -j4
+sudo apt-get update
+sudo apt-get install -y cmake ninja-build libeigen3-dev libceres-dev nlohmann-json3-dev
 ```
 
-To install:
+#### macOS
 
 ```bash
-cmake --build . --target install
+brew update
+brew install cmake ninja eigen ceres-solver nlohmann-json
+```
+
+Configure and build:
+
+```bash
+cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+cmake --build build -j2
+```
+
+Run a smoke test:
+
+```bash
+./build/examples/homography <<EOF
+4
+0   0    10 20
+100 0    110 18
+100 50   120 70
+0   50   8  72
+EOF
+```
+
+### Windows
+
+Install dependencies with [vcpkg](https://github.com/microsoft/vcpkg):
+
+```powershell
+git clone https://github.com/microsoft/vcpkg $env:USERPROFILE\vcpkg
+& $env:USERPROFILE\vcpkg\bootstrap-vcpkg.bat
+& $env:USERPROFILE\vcpkg\vcpkg.exe install ceres eigen3 nlohmann-json --triplet x64-windows
+```
+
+Configure and build:
+
+```powershell
+cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release `
+  -DCMAKE_TOOLCHAIN_FILE="$env:USERPROFILE\vcpkg\scripts\buildsystems\vcpkg.cmake"
+cmake --build build --config Release -j2
+```
+
+Run a smoke test:
+
+```powershell
+build\examples\homography.exe <<'EOF'
+4
+0   0    10 20
+100 0    110 18
+100 50   120 70
+0   50   8  72
+EOF
 ```
 
 ## Usage
@@ -58,7 +102,7 @@ For detailed documentation, see the [docs](docs/) directory.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENCE](LICENCE) file for details.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Document cross-platform build steps for Linux/macOS and Windows, mirroring CI configuration
- Point README CI badge to `ci.yml` and fix licence link

## Testing
- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release` *(fails: Could not find CeresConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c85f56d8833297b266fe31b84fab