### PR TITLE
Add unit tests for distortion and intrinsics optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,5 +8,19 @@ find_package(Ceres CONFIG REQUIRED)
 find_package(Eigen3 CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
 
+# Add GTest
+include(FetchContent)
+FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/refs/tags/v1.13.0.tar.gz
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+enable_testing()
+
 add_subdirectory(src)
 add_subdirectory(examples)
+add_subdirectory(test)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Calibration Library
 
-[![Build Status](https://github.com/VitalyVorobyev/calibration/actions/workflows/build.yml/badge.svg)](https://github.com/VitalyVorobyev/calibration/actions/workflows/build.yml)
+[![Build Status](https://github.com/VitalyVorobyev/calibration/actions/workflows/ci.yml/badge.svg)](https://github.com/VitalyVorobyev/calibration/actions/ci/build.yml)
 
 A C++ library for camera calibration and vision-related geometric transformations.
 

--- a/README.md
+++ b/README.md
@@ -19,19 +19,6 @@ A C++ library for camera calibration and vision-related geometric transformation
 - nlohmann-json: JSON parsing and serialization
 - GoogleTest & GoogleMock: Unit testing frameworks
 
-## Installation
-
-### Ubuntu
-
-```bash
-sudo apt install libeigen3-dev libceres-dev nlohmann-json3-dev libgtest-dev libgmock-dev
-```
-These packages install both GoogleTest and GoogleMock, which are needed to build and run the unit tests.
-
-### Other platforms
-
-For other platforms, please install the equivalent dependencies using your system's package manager.
-
 ## Build
 
 ### Linux and macOS
@@ -41,15 +28,15 @@ Install the build dependencies using your system package manager.
 #### Ubuntu
 
 ```bash
-sudo apt-get update
-sudo apt-get install -y cmake ninja-build libeigen3-dev libceres-dev nlohmann-json3-dev
+sudo apt update
+sudo apt install -y cmake ninja-build libeigen3-dev libceres-dev nlohmann-json3-dev libgtest-dev libgmock-dev
 ```
 
 #### macOS
 
 ```bash
 brew update
-brew install cmake ninja eigen ceres-solver nlohmann-json
+brew install cmake ninja eigen ceres-solver nlohmann-json googletest
 ```
 
 Configure and build:
@@ -78,7 +65,7 @@ Install dependencies with [vcpkg](https://github.com/microsoft/vcpkg):
 ```powershell
 git clone https://github.com/microsoft/vcpkg $env:USERPROFILE\vcpkg
 & $env:USERPROFILE\vcpkg\bootstrap-vcpkg.bat
-& $env:USERPROFILE\vcpkg\vcpkg.exe install ceres eigen3 nlohmann-json --triplet x64-windows
+& $env:USERPROFILE\vcpkg\vcpkg.exe install ceres eigen3 nlohmann-json gtest --triplet x64-windows
 ```
 
 Configure and build:
@@ -92,7 +79,7 @@ cmake --build build --config Release -j2
 Run a smoke test:
 
 ```powershell
-build\examples\homography.exe <<'EOF'
+build\examples\homography.exe <<EOF
 4
 0   0    10 20
 100 0    110 18
@@ -103,11 +90,7 @@ EOF
 
 ## Usage
 
-```cpp
-#include <calib/camera.h>
-
-// Example code will go here
-```
+TODO
 
 ## Documentation
 

--- a/include/calibration/distortion.h
+++ b/include/calibration/distortion.h
@@ -1,0 +1,36 @@
+/** @brief Linear least squares design matrix for distortion parameters */
+
+#pragma once
+
+// std
+#include <vector>
+
+// eigen
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
+namespace vitavision {
+
+struct Observation {
+    double x, y;   // normalized undistorted coords
+    double u, v;   // observed distorted pixel coords
+};
+
+Eigen::VectorXd fit_distortion(
+    const std::vector<Observation>& obs,
+    double fx, double fy, double cx, double cy,
+    size_t num_radial = 2);
+
+
+struct LSDesign {
+    // Build A * alpha ≈ b, where alpha = [k1..kK, p1, p2]^T
+    static void build(const std::vector<Observation>& obs,
+                      int num_radial,
+                      double fx, double fy, double cx, double cy,
+                      Eigen::MatrixXd& A, Eigen::VectorXd& b);
+
+    // Solve (A^T A) alpha = A^T b
+    static Eigen::VectorXd solveNormal(const Eigen::MatrixXd& A, const Eigen::VectorXd& b);
+};
+
+}  // namespace vitavision

--- a/include/calibration/intrinsics.h
+++ b/include/calibration/intrinsics.h
@@ -1,0 +1,34 @@
+/** @brief Optimization of camera intrinsics parameters */
+
+#pragma once
+
+// std
+#include <optional>
+
+// eigen
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
+#include "calibration/distortion.h"  // Observation
+
+namespace vitavision {
+
+struct Intrinsic {
+    double fx, fy, cx, cy;
+};
+
+struct IntrinsicOptimizationResult {
+    Intrinsic intrinsics;
+    Eigen::VectorXd distortion;
+    std::string summary; // Summary of optimization results
+    Eigen::Matrix4d covariance; // Covariance matrix of intrinsics
+};
+
+IntrinsicOptimizationResult optimize_intrinsics(
+    const std::vector<Observation>& obs,
+    int num_radial,
+    const Intrinsic& initial_guess,
+    bool verb=false
+);
+
+}  // namespace vitavision

--- a/src/distortion.cpp
+++ b/src/distortion.cpp
@@ -1,0 +1,70 @@
+#include "calibration/distortion.h"
+
+namespace vitavision {
+
+void LSDesign::build(const std::vector<Observation>& obs,
+                     int num_radial,
+                     double fx, double fy, double cx, double cy,
+                     Eigen::MatrixXd& A, Eigen::VectorXd& b) {
+    const int M = num_radial + 2;  // radial Ks + (p1, p2)
+    const int rows = static_cast<int>(obs.size()) * 2;
+    A.setZero(rows, M);
+    b.setZero(rows);
+
+    // Tangential p1, p2 (last two columns)
+    const int idx_p1 = num_radial;
+    const int idx_p2 = num_radial + 1;
+
+    for (int i = 0, n = static_cast<int>(obs.size()); i < n; ++i) {
+        const double x = obs[i].x;
+        const double y = obs[i].y;
+        const double r2 = x*x + y*y;
+
+        const double u0 = fx * x + cx;
+        const double v0 = fy * y + cy;
+
+        const double du = obs[i].u - u0;
+        const double dv = obs[i].v - v0;
+
+        const int ru = 2*i;
+        const int rv = 2*i + 1;
+
+        // Radial columns
+        double rpow = r2; // r^(2*1)
+        for (int j = 0; j < num_radial; ++j) {
+            A(ru, j) = fx * x * rpow;
+            A(rv, j) = fy * y * rpow;
+            rpow *= r2; // next power
+        }
+
+        // u_tangential = fx*(2*p1*x*y + p2*(r^2 + 2x^2))
+        A(ru, idx_p1) = fx * (2.0 * x * y);
+        A(ru, idx_p2) = fx * (r2 + 2.0 * x * x);
+
+        // v_tangential = fy*(p1*(r^2 + 2y^2) + 2*p2*x*y)
+        A(rv, idx_p1) = fy * (r2 + 2.0 * y * y);
+        A(rv, idx_p2) = fy * (2.0 * x * y);
+
+        // Right-hand side: observed - undistorted
+        b(ru) = du;
+        b(rv) = dv;
+    }
+}
+
+// Solve (A^T A) alpha = A^T b
+Eigen::VectorXd LSDesign::solveNormal(const Eigen::MatrixXd& A, const Eigen::VectorXd& b) {
+    return (A.transpose() * A).ldlt().solve(A.transpose() * b);
+}
+
+Eigen::VectorXd fit_distortion(
+    const std::vector<Observation>& obs,
+    double fx, double fy, double cx, double cy,
+    size_t num_radial
+) {
+    Eigen::MatrixXd A;
+    Eigen::VectorXd b;
+    LSDesign::build(obs, num_radial, fx, fy, cx, cy, A, b);
+    return LSDesign::solveNormal(A, b);
+}
+
+}  // namespace vitavision

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -1,0 +1,213 @@
+#include "calibration/intrinsics.h"
+
+// std
+#include <iostream>
+#include <random>
+#include <cmath>
+
+// ceres
+#include <ceres/ceres.h>
+
+namespace vitavision {
+
+// CostFunction that does variable projection and finite-difference Jacobians.
+class IntrinsicsVPResidual : public ceres::CostFunction {
+    void computeResiduals(const double intr[4], double* residuals) const {
+        Eigen::MatrixXd A;
+        Eigen::VectorXd b;
+        LSDesign::build(obs_, num_radial_, intr[0], intr[1], intr[2], intr[3], A, b);
+        Eigen::VectorXd alpha = LSDesign::solveNormal(A, b);
+
+        // Predicted minus observed = (u0 + A*alpha) - (u_obs, v_obs)  ==  A*alpha - b
+        Eigen::VectorXd r = A * alpha - b;
+        // Copy out
+        for (int i = 0; i < r.size(); ++i) residuals[i] = r[i];
+    }
+
+    std::vector<Observation> obs_;
+    int num_radial_;
+
+public:
+    IntrinsicsVPResidual(std::vector<Observation> obs, int num_radial)
+        : obs_(std::move(obs)), num_radial_(num_radial)
+    {
+        set_num_residuals(static_cast<int>(obs_.size()) * 2);
+        // Single parameter block: [fx, fy, cx, cy]
+        mutable_parameter_block_sizes()->push_back(4);
+    }
+
+    bool Evaluate(double const* const* parameters,
+                  double* residuals,
+                  double** jacobians) const override {
+        const double* intr = parameters[0];
+        computeResiduals(intr, residuals);
+
+        if (jacobians && jacobians[0]) {
+            // Central finite differences on intrinsics
+            double* J = jacobians[0];
+            const int m = num_residuals();
+            const double base[4] = {intr[0], intr[1], intr[2], intr[3]};
+
+            std::vector<double> r_plus(m), r_minus(m);
+            for (int k = 0; k < 4; ++k) {
+                double step = 1e-6 * std::max(1.0, std::abs(base[k]));
+                double intr_p[4] = { base[0], base[1], base[2], base[3] };
+                double intr_m[4] = { base[0], base[1], base[2], base[3] };
+                intr_p[k] += step;
+                intr_m[k] -= step;
+
+                computeResiduals(intr_p, r_plus.data());
+                computeResiduals(intr_m, r_minus.data());
+
+                for (int i = 0; i < m; ++i) {
+                    J[i * 4 + k] = (r_plus[i] - r_minus[i]) / (2.0 * step);
+                }
+            }
+        }
+        return true;
+    }
+
+    // Compute optimal distortion coeffs for given intrinsics (useful after Solve).
+    Eigen::VectorXd SolveDistortionFor(const double intr[4]) const {
+        return fit_distortion(obs_, intr[0], intr[1], intr[2], intr[3], num_radial_);
+    }
+};
+
+static Eigen::Matrix4d compute_covariance(
+    size_t n_obs,
+    const IntrinsicsVPResidual& vp,
+    double const* intrinsics,
+    ceres::Problem& problem
+) {
+    // Recompute residuals and RMSE
+    const int m = static_cast<int>(n_obs) * 2;
+    std::vector<double> residuals(2 * n_obs);
+    
+    // Fix: Create parameter array for Evaluate
+    const double* params[1] = {intrinsics};
+    vp.Evaluate(params, residuals.data(), nullptr);
+
+    double ssr = 0.0;
+    for (double r : residuals) ssr += r * r;
+    const int dof = m - 4; // 4 nonlinear params in this problem
+    const double rmse = std::sqrt(ssr / m);
+    const double sigma2 = ssr / std::max(1, dof);
+    std::cout << "RMSE (pixels): " << rmse << "\n";
+
+    // Covariance (approximate): scale by residual variance.
+    ceres::Covariance::Options cov_opts;
+    ceres::Covariance cov(cov_opts);
+    std::vector<std::pair<const double*, const double*>> blocks = { {intrinsics, intrinsics} };
+    if (!cov.Compute(blocks, &problem)) {
+        std::cerr << "Covariance computation failed.\n";
+        return Eigen::Matrix4d::Zero();
+    }
+
+    double cov4x4[16];
+    cov.GetCovarianceBlock(intrinsics, intrinsics, cov4x4);
+
+    // Scale by estimated noise variance (unit weights assumption).
+    Eigen::Map<Eigen::Matrix4d> covar(cov4x4);
+    covar *= sigma2;
+    return covar;
+}
+
+IntrinsicOptimizationResult optimize_intrinsics(
+    const std::vector<Observation>& obs,
+    int num_radial,
+    const Intrinsic& initial_guess,
+    bool verb
+) {
+    double intrinsics[4] = {
+        initial_guess.fx,
+        initial_guess.fy,
+        initial_guess.cx,
+        initial_guess.cy
+    };
+
+    ceres::Problem problem;
+    #if 0
+    auto costptr = std::make_unique<IntrinsicsVPResidual>(obs, num_radial);
+    #else
+    auto costptr = new IntrinsicsVPResidual(obs, num_radial);
+    #endif
+
+    problem.AddResidualBlock(costptr, /*loss=*/nullptr, intrinsics);
+
+    ceres::Solver::Options options;
+    options.linear_solver_type = ceres::DENSE_QR;
+    options.minimizer_progress_to_stdout = verb;
+    options.function_tolerance = 1e-12;
+    options.gradient_tolerance = 1e-12;
+    options.parameter_tolerance = 1e-12;
+
+    ceres::Solver::Summary summary;
+    ceres::Solve(options, &problem, &summary);
+
+    IntrinsicOptimizationResult result;
+    result.intrinsics.fx = intrinsics[0];
+    result.intrinsics.fy = intrinsics[1];
+    result.intrinsics.cx = intrinsics[2];
+    result.intrinsics.cy = intrinsics[3];
+    result.distortion = fit_distortion(
+        obs, intrinsics[0], intrinsics[1], intrinsics[2], intrinsics[3], num_radial);
+    result.summary = summary.BriefReport();
+    
+    // Fix: Pass the cost function object reference instead of intrinsics array
+    result.covariance = compute_covariance(obs.size(), *costptr, intrinsics, problem);
+
+    return result;
+}
+
+#if 0
+// ---------- Demo / usage ----------
+int main() {
+  // Synthetic data for demonstration.
+  std::mt19937 rng(42);
+  std::uniform_real_distribution<double> uni(-0.6, 0.6);
+  std::normal_distribution<double> noise(0.0, 0.2); // pixel noise
+
+  // True intrinsics & distortion
+  const double fx_true = 800.0, fy_true = 820.0, cx_true = 640.0, cy_true = 360.0;
+  const std::vector<double> k_true = {-0.20, 0.03}; // k1, k2
+  const double p1_true = 0.0010, p2_true = -0.0005;
+
+  const int N = 300;     // points
+  const int K = 2;       // number of radial coeffs to estimate
+  std::vector<Observation> obs; obs.reserve(N);
+
+  auto distort_then_project = [&](double x, double y,
+                                  double& u, double& v) {
+    const double r2 = x*x + y*y;
+    double radial = 1.0;
+    double rpow = r2;
+    for (double kj : k_true) { radial += kj * rpow; rpow *= r2; }
+
+    double x_t = x * radial + 2.0 * p1_true * x * y + p2_true * (r2 + 2.0 * x * x);
+    double y_t = y * radial + p1_true * (r2 + 2.0 * y * y) + 2.0 * p2_true * x * y;
+
+    u = fx_true * x_t + cx_true;
+    v = fy_true * y_t + cy_true;
+  };
+
+  for (int i = 0; i < N; ++i) {
+    double x = uni(rng), y = uni(rng);
+    double u, v; distort_then_project(x, y, u, v);
+    obs.push_back({x, y, u + noise(rng), v + noise(rng)});
+  }
+
+  // Initial guess (slightly off)
+  double intrinsics[4] = {780.0, 800.0, 630.0, 350.0};
+
+  auto result = optimize_intrinsics(obs, K, intrinsics, true);
+
+  std::cout << "Std. deviations (1-sigma):\n";
+  for (int i = 0; i < 4; ++i) {
+    double s = std::sqrt(std::max(0.0, result.covariance(i,i)));
+    std::cout << "  param[" << i << "] = " << s << "\n";
+  }
+  return 0;
+}
+#endif
+
+}  // namespace vitavision

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,31 @@
+include(GoogleTest)
+
+# Test for homography estimation
+add_executable(homography_test homography_test.cpp)
+target_link_libraries(homography_test 
+    PRIVATE calibration
+    PRIVATE GTest::gtest_main
+    PRIVATE GTest::gmock_main
+    PRIVATE Eigen3::Eigen
+)
+gtest_discover_tests(homography_test)
+
+# Test for distortion calculation
+add_executable(distortion_test distortion_test.cpp)
+target_link_libraries(distortion_test 
+    PRIVATE calibration
+    PRIVATE GTest::gtest_main
+    PRIVATE GTest::gmock_main
+    PRIVATE Eigen3::Eigen
+)
+gtest_discover_tests(distortion_test)
+
+# Test for camera intrinsics optimization
+add_executable(intrinsics_test intrinsics_test.cpp)
+target_link_libraries(intrinsics_test 
+    PRIVATE calibration
+    PRIVATE GTest::gtest_main
+    PRIVATE GTest::gmock_main
+    PRIVATE Eigen3::Eigen
+)
+gtest_discover_tests(intrinsics_test)

--- a/test/distortion_test.cpp
+++ b/test/distortion_test.cpp
@@ -1,0 +1,174 @@
+#include "calibration/distortion.h"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <random>
+#include <cmath>
+
+using namespace vitavision;
+using Vec2 = Eigen::Vector2d;
+
+namespace {
+
+// Helper to apply distortion to a point
+void distort_point(double x, double y, 
+                   const std::vector<double>& k_radial,
+                   double p1, double p2,
+                   double& x_distorted, double& y_distorted) {
+    const double r2 = x*x + y*y;
+    
+    // Apply radial distortion
+    double radial = 1.0;
+    double rpow = r2;
+    for (double k : k_radial) {
+        radial += k * rpow;
+        rpow *= r2;
+    }
+    
+    // Apply tangential distortion
+    x_distorted = x * radial + 2.0 * p1 * x * y + p2 * (r2 + 2.0 * x * x);
+    y_distorted = y * radial + p1 * (r2 + 2.0 * y * y) + 2.0 * p2 * x * y;
+}
+
+// Generate synthetic observations with known distortion
+std::vector<Observation> generate_synthetic_data(
+    const std::vector<double>& k_radial,
+    double p1, double p2,
+    double fx, double fy, double cx, double cy,
+    int n_points = 100,
+    double noise_level = 0.0) {
+    
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<double> dist(-0.6, 0.6); // Normalized coords
+    std::normal_distribution<double> noise(0.0, noise_level);
+    
+    std::vector<Observation> observations;
+    observations.reserve(n_points);
+    
+    for (int i = 0; i < n_points; ++i) {
+        double x = dist(rng);
+        double y = dist(rng);
+        
+        // Apply distortion
+        double x_distorted, y_distorted;
+        distort_point(x, y, k_radial, p1, p2, x_distorted, y_distorted);
+        
+        // Project to pixel coords
+        double u = fx * x_distorted + cx;
+        double v = fy * y_distorted + cy;
+        
+        // Add noise
+        u += noise(rng);
+        v += noise(rng);
+        
+        observations.push_back({x, y, u, v});
+    }
+    
+    return observations;
+}
+
+// Custom matcher for vector comparison
+MATCHER_P2(IsVectorNear, expected, tolerance, "") {
+    bool result = arg.size() == expected.size();
+    if (!result) return false;
+    
+    for (size_t i = 0; i < arg.size() && result; ++i) {
+        result = std::abs(arg[i] - expected[i]) < tolerance;
+    }
+    return result;
+}
+
+} // anonymous namespace
+
+TEST(DistortionTest, ExactFit) {
+    // Camera intrinsics
+    double fx = 800.0, fy = 800.0, cx = 400.0, cy = 300.0;
+    
+    // True distortion coefficients
+    std::vector<double> k_true = {-0.2, 0.05};  // k1, k2
+    double p1_true = 0.001, p2_true = -0.0005;
+    
+    // Generate perfect synthetic data
+    auto observations = generate_synthetic_data(
+        k_true, p1_true, p2_true, fx, fy, cx, cy, 500, 0.0);
+    
+    // Fit distortion parameters
+    Eigen::VectorXd distortion = fit_distortion(observations, fx, fy, cx, cy, 2);
+    
+    // Check results
+    EXPECT_NEAR(distortion[0], k_true[0], 1e-10);
+    EXPECT_NEAR(distortion[1], k_true[1], 1e-10);
+    EXPECT_NEAR(distortion[2], p1_true, 1e-10);
+    EXPECT_NEAR(distortion[3], p2_true, 1e-10);
+}
+
+TEST(DistortionTest, NoisyFit) {
+    // Camera intrinsics
+    double fx = 800.0, fy = 820.0, cx = 400.0, cy = 300.0;
+    
+    // True distortion coefficients
+    std::vector<double> k_true = {-0.2, 0.05};  // k1, k2
+    double p1_true = 0.001, p2_true = -0.0005;
+    
+    // Generate synthetic data with noise
+    auto observations = generate_synthetic_data(
+        k_true, p1_true, p2_true, fx, fy, cx, cy, 1000, 0.5);
+    
+    // Fit distortion parameters
+    Eigen::VectorXd distortion = fit_distortion(observations, fx, fy, cx, cy, 2);
+    
+    // Results should be close but not exact due to noise
+    EXPECT_NEAR(distortion[0], k_true[0], 0.01);
+    EXPECT_NEAR(distortion[1], k_true[1], 0.01);
+    EXPECT_NEAR(distortion[2], p1_true, 0.001);
+    EXPECT_NEAR(distortion[3], p2_true, 0.001);
+}
+
+TEST(DistortionTest, LSDesignMatrix) {
+    // Test building the design matrix
+    double fx = 800.0, fy = 800.0, cx = 400.0, cy = 300.0;
+    
+    std::vector<Observation> obs = {
+        {0.1, 0.2, 490.0, 470.0},  // x, y, u, v
+        {-0.3, 0.4, 320.0, 630.0}
+    };
+    
+    Eigen::MatrixXd A;
+    Eigen::VectorXd b;
+    const int num_radial = 2;
+    
+    LSDesign::build(obs, num_radial, fx, fy, cx, cy, A, b);
+    
+    // Check dimensions
+    EXPECT_EQ(A.rows(), 4);  // 2 observations * 2 coordinates
+    EXPECT_EQ(A.cols(), 4);  // 2 radial + 2 tangential
+    EXPECT_EQ(b.size(), 4);
+    
+    // Check right-hand side (observed - undistorted)
+    EXPECT_NEAR(b(0), 490.0 - (fx * 0.1 + cx), 1e-10);
+    EXPECT_NEAR(b(1), 470.0 - (fy * 0.2 + cy), 1e-10);
+    EXPECT_NEAR(b(2), 320.0 - (fx * -0.3 + cx), 1e-10);
+    EXPECT_NEAR(b(3), 630.0 - (fy * 0.4 + cy), 1e-10);
+}
+
+TEST(DistortionTest, NormalEquations) {
+    Eigen::MatrixXd A(4, 2);
+    A << 1.0, 2.0,
+         3.0, 4.0,
+         5.0, 6.0,
+         7.0, 8.0;
+    
+    Eigen::VectorXd b(4);
+    b << 10.0, 20.0, 30.0, 40.0;
+    
+    // Solve normal equations
+    Eigen::VectorXd x = LSDesign::solveNormal(A, b);
+    
+    // Verify solution is correct for this simple case
+    Eigen::MatrixXd AtA = A.transpose() * A;
+    Eigen::VectorXd Atb = A.transpose() * b;
+    Eigen::VectorXd expected = AtA.ldlt().solve(Atb);
+    
+    EXPECT_NEAR(x(0), expected(0), 1e-10);
+    EXPECT_NEAR(x(1), expected(1), 1e-10);
+}

--- a/test/homography_test.cpp
+++ b/test/homography_test.cpp
@@ -1,0 +1,149 @@
+#include "calibration/homography.h"
+
+// std
+#include <random>
+#include <cmath>
+
+// gtest
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+using namespace vitavision;
+using Vec2 = Eigen::Vector2d;
+using Mat3 = Eigen::Matrix3d;
+
+namespace {
+
+// Custom matcher for floating point matrix comparisons
+MATCHER_P(IsMatrixNear, expected, "") {
+    bool result = arg.rows() == expected.rows() && arg.cols() == expected.cols();
+    if (!result) return false;
+    
+    for (int i = 0; i < arg.rows() && result; ++i) {
+        for (int j = 0; j < arg.cols() && result; ++j) {
+            result = std::abs(arg(i, j) - expected(i, j)) < 1e-6;
+        }
+    }
+    return result;
+}
+
+// Helper to apply a homography to a point
+Vec2 apply_homography(const Mat3& H, const Vec2& p) {
+    Eigen::Vector3d ph(p.x(), p.y(), 1.0);
+    Eigen::Vector3d q = H * ph;
+    return Vec2(q.x() / q.z(), q.y() / q.z());
+}
+
+// Generate synthetic data with a known homography
+void generate_synthetic_data(std::vector<Vec2>& src, 
+                             std::vector<Vec2>& dst, 
+                             Mat3& true_H,
+                             int n_points = 50,
+                             double noise_level = 0.5) {
+    // Create a non-trivial homography (rotation + translation + perspective)
+    const double angle = 0.1;  // radians
+    const double c = std::cos(angle), s = std::sin(angle);
+    const double tx = 10.0, ty = -5.0;
+    true_H << c, -s, tx,
+              s,  c, ty,
+              0.001, -0.002, 1.0;
+    
+    // Normalize the scale
+    true_H /= true_H(2, 2);
+    
+    // Random number generator
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<double> dist(-100.0, 100.0);
+    std::normal_distribution<double> noise(0.0, noise_level);
+    
+    src.resize(n_points);
+    dst.resize(n_points);
+    
+    for (int i = 0; i < n_points; ++i) {
+        // Random source point
+        src[i] = Vec2(dist(rng), dist(rng));
+        
+        // Apply true homography
+        Vec2 exact_dst = apply_homography(true_H, src[i]);
+        
+        // Add noise to destination points
+        dst[i] = Vec2(exact_dst.x() + noise(rng), exact_dst.y() + noise(rng));
+    }
+}
+
+} // anonymous namespace
+
+TEST(HomographyTest, ExactHomography) {
+    // Create a simple homography (pure translation)
+    Mat3 H_true = Mat3::Identity();
+    H_true(0, 2) = 10.0;  // x translation
+    H_true(1, 2) = -5.0;  // y translation
+    
+    // Create source and destination points with exact transformation
+    std::vector<Vec2> src = {
+        {0.0, 0.0},
+        {1.0, 0.0},
+        {0.0, 1.0},
+        {1.0, 1.0}
+    };
+    
+    std::vector<Vec2> dst;
+    dst.reserve(src.size());
+    for (const auto& p : src) {
+        dst.push_back(apply_homography(H_true, p));
+    }
+    
+    // Estimate homography
+    Mat3 H_est = fit_homography(src, dst);
+    
+    // The estimated homography should be very close to the true one
+    EXPECT_THAT(H_est, IsMatrixNear(H_true));
+}
+
+TEST(HomographyTest, NoisyHomography) {
+    std::vector<Vec2> src, dst;
+    Mat3 H_true;
+    
+    // Generate data with low noise
+    generate_synthetic_data(src, dst, H_true, 50, 0.1);
+    
+    // Estimate homography
+    Mat3 H_est = fit_homography(src, dst);
+    
+    // Verify that the estimated homography is close to the ground truth
+    // with some tolerance for noise
+    double tolerance = 1e-2;
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+            EXPECT_NEAR(H_est(i, j), H_true(i, j), tolerance) 
+                << "Matrix differs at (" << i << "," << j << ")";
+        }
+    }
+    
+    // Check the reprojection error
+    double avg_error = 0.0;
+    for (size_t i = 0; i < src.size(); ++i) {
+        Vec2 projected = apply_homography(H_est, src[i]);
+        avg_error += (projected - dst[i]).norm();
+    }
+    avg_error /= src.size();
+    
+    // Average reprojection error should be small
+    EXPECT_LT(avg_error, 0.15); // Should be close to the noise level
+}
+
+TEST(HomographyTest, InsufficientPoints) {
+    // Less than 4 points should throw an exception
+    std::vector<Vec2> src = {{0.0, 0.0}, {1.0, 0.0}, {0.0, 1.0}};
+    std::vector<Vec2> dst = {{10.0, 0.0}, {11.0, 0.0}, {10.0, 1.0}};
+    
+    EXPECT_THROW(fit_homography(src, dst), std::invalid_argument);
+}
+
+TEST(HomographyTest, MismatchedSizes) {
+    // Different number of source and destination points should throw
+    std::vector<Vec2> src = {{0.0, 0.0}, {1.0, 0.0}, {0.0, 1.0}, {1.0, 1.0}};
+    std::vector<Vec2> dst = {{10.0, 0.0}, {11.0, 0.0}, {10.0, 1.0}};
+    
+    EXPECT_THROW(fit_homography(src, dst), std::invalid_argument);
+}

--- a/test/intrinsics_test.cpp
+++ b/test/intrinsics_test.cpp
@@ -1,0 +1,193 @@
+#include "calibration/intrinsics.h"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <random>
+#include <cmath>
+
+using namespace vitavision;
+using Vec2 = Eigen::Vector2d;
+
+namespace {
+
+// Helper function to distort a point with given intrinsics and distortion
+void distort_and_project(double x, double y,
+                         const Intrinsic& intr,
+                         const std::vector<double>& k_radial,
+                         double p1, double p2,
+                         double& u, double& v) {
+    const double r2 = x*x + y*y;
+    
+    // Apply radial distortion
+    double radial = 1.0;
+    double rpow = r2;
+    for (double k : k_radial) {
+        radial += k * rpow;
+        rpow *= r2;
+    }
+    
+    // Apply tangential distortion
+    double x_t = x * radial + 2.0 * p1 * x * y + p2 * (r2 + 2.0 * x * x);
+    double y_t = y * radial + p1 * (r2 + 2.0 * y * y) + 2.0 * p2 * x * y;
+    
+    // Project to pixel coords
+    u = intr.fx * x_t + intr.cx;
+    v = intr.fy * y_t + intr.cy;
+}
+
+// Generate synthetic observations with known intrinsics and distortion
+std::vector<Observation> generate_synthetic_data(
+    const Intrinsic& intr_true,
+    const std::vector<double>& k_radial,
+    double p1, double p2,
+    int n_points = 300,
+    double noise_level = 0.2) {
+    
+    std::mt19937 rng(42);
+    std::uniform_real_distribution<double> dist(-0.6, 0.6); // Normalized coords
+    std::normal_distribution<double> noise(0.0, noise_level);
+    
+    std::vector<Observation> observations;
+    observations.reserve(n_points);
+    
+    for (int i = 0; i < n_points; ++i) {
+        double x = dist(rng);
+        double y = dist(rng);
+        
+        // Apply distortion and projection
+        double u, v;
+        distort_and_project(x, y, intr_true, k_radial, p1, p2, u, v);
+        
+        // Add noise
+        u += noise(rng);
+        v += noise(rng);
+        
+        observations.push_back({x, y, u, v});
+    }
+    
+    return observations;
+}
+
+} // anonymous namespace
+
+TEST(IntrinsicsTest, OptimizeExact) {
+    // True intrinsics
+    Intrinsic intr_true{800.0, 820.0, 640.0, 360.0};
+    
+    // True distortion
+    std::vector<double> k_radial = {-0.20, 0.03};
+    double p1 = 0.001, p2 = -0.0005;
+    
+    // Generate perfect synthetic data
+    auto observations = generate_synthetic_data(
+        intr_true, k_radial, p1, p2, 300, 0.0);
+    
+    // Initial guess (slightly off)
+    Intrinsic initial_guess{780.0, 800.0, 630.0, 350.0};
+    
+    // Optimize
+    auto result = optimize_intrinsics(observations, 2, initial_guess, false);
+    
+    // Check results
+    EXPECT_NEAR(result.intrinsics.fx, intr_true.fx, 1e-6);
+    EXPECT_NEAR(result.intrinsics.fy, intr_true.fy, 1e-6);
+    EXPECT_NEAR(result.intrinsics.cx, intr_true.cx, 1e-6);
+    EXPECT_NEAR(result.intrinsics.cy, intr_true.cy, 1e-6);
+    
+    EXPECT_NEAR(result.distortion[0], k_radial[0], 1e-6);
+    EXPECT_NEAR(result.distortion[1], k_radial[1], 1e-6);
+    EXPECT_NEAR(result.distortion[2], p1, 1e-6);
+    EXPECT_NEAR(result.distortion[3], p2, 1e-6);
+}
+
+TEST(IntrinsicsTest, OptimizeNoisy) {
+    // True intrinsics
+    Intrinsic intr_true{800.0, 820.0, 640.0, 360.0};
+    
+    // True distortion
+    std::vector<double> k_radial = {-0.20, 0.03};
+    double p1 = 0.001, p2 = -0.0005;
+    
+    // Generate synthetic data with noise
+    auto observations = generate_synthetic_data(
+        intr_true, k_radial, p1, p2, 500, 0.5);
+    
+    // Initial guess (slightly off)
+    Intrinsic initial_guess{780.0, 800.0, 630.0, 350.0};
+    
+    // Optimize
+    auto result = optimize_intrinsics(observations, 2, initial_guess, false);
+    
+    // Check results (with tolerance for noise)
+    EXPECT_NEAR(result.intrinsics.fx, intr_true.fx, 10.0);
+    EXPECT_NEAR(result.intrinsics.fy, intr_true.fy, 10.0);
+    EXPECT_NEAR(result.intrinsics.cx, intr_true.cx, 5.0);
+    EXPECT_NEAR(result.intrinsics.cy, intr_true.cy, 5.0);
+    
+    EXPECT_NEAR(result.distortion[0], k_radial[0], 0.05);
+    EXPECT_NEAR(result.distortion[1], k_radial[1], 0.05);
+    EXPECT_NEAR(result.distortion[2], p1, 0.001);
+    EXPECT_NEAR(result.distortion[3], p2, 0.001);
+    
+    // Check covariance matrix is valid (positive definite)
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix4d> eigensolver(result.covariance);
+    EXPECT_GT(eigensolver.eigenvalues().minCoeff(), 0.0);
+}
+
+TEST(IntrinsicsTest, DifferentRadialCoeffs) {
+    // Test with different numbers of radial coefficients
+    Intrinsic intr_true{800.0, 820.0, 640.0, 360.0};
+    
+    // True distortion with 3 radial terms
+    std::vector<double> k_radial = {-0.20, 0.03, 0.01};
+    double p1 = 0.001, p2 = -0.0005;
+    
+    // Generate synthetic data
+    auto observations = generate_synthetic_data(
+        intr_true, k_radial, p1, p2, 300, 0.1);
+    
+    // Initial guess
+    Intrinsic initial_guess{780.0, 800.0, 630.0, 350.0};
+    
+    // Optimize with 1, 2, and 3 radial coefficients
+    auto result1 = optimize_intrinsics(observations, 1, initial_guess, false);
+    auto result2 = optimize_intrinsics(observations, 2, initial_guess, false);
+    auto result3 = optimize_intrinsics(observations, 3, initial_guess, false);
+    
+    // Check that results improve with more coefficients
+    EXPECT_EQ(result1.distortion.size(), 3);  // 1 radial + 2 tangential
+    EXPECT_EQ(result2.distortion.size(), 4);  // 2 radial + 2 tangential
+    EXPECT_EQ(result3.distortion.size(), 5);  // 3 radial + 2 tangential
+    
+    // The third model should be closest to the true values
+    EXPECT_NEAR(result3.distortion[0], k_radial[0], 0.05);
+    EXPECT_NEAR(result3.distortion[1], k_radial[1], 0.05);
+    EXPECT_NEAR(result3.distortion[2], k_radial[2], 0.05);
+}
+
+TEST(IntrinsicsTest, OptimizationSummary) {
+    // True intrinsics
+    Intrinsic intr_true{800.0, 820.0, 640.0, 360.0};
+    
+    // True distortion
+    std::vector<double> k_radial = {-0.20, 0.03};
+    double p1 = 0.001, p2 = -0.0005;
+    
+    // Generate synthetic data
+    auto observations = generate_synthetic_data(
+        intr_true, k_radial, p1, p2, 100, 0.1);
+    
+    // Initial guess
+    Intrinsic initial_guess{780.0, 800.0, 630.0, 350.0};
+    
+    // Optimize with verbose output
+    auto result = optimize_intrinsics(observations, 2, initial_guess, true);
+    
+    // Check that the summary is not empty
+    EXPECT_FALSE(result.summary.empty());
+
+    // Should contain success or convergence information
+    EXPECT_TRUE(result.summary.find("Iterations") != std::string::npos && 
+                result.summary.find("Final cost") != std::string::npos &&
+                result.summary.find("CONVERGENCE") != std::string::npos);
+}


### PR DESCRIPTION
- Implement tests for distortion calculations, including exact and noisy fits.
- Create tests for intrinsics optimization with varying radial coefficients.
- Add homography tests to validate transformation accuracy.
- Enhance CMake configuration to include new test executables.