### PR TITLE
Add CI test stage and use system-provided gtest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,14 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build libeigen3-dev libceres-dev nlohmann-json3-dev
+          sudo apt-get install -y cmake ninja-build libeigen3-dev libceres-dev nlohmann-json3-dev libgtest-dev
 
       # ---------- macOS deps ----------
       - name: Install deps (macOS)
         if: startsWith(matrix.os, 'macos')
         run: |
           brew update
-          brew install cmake ninja eigen ceres-solver nlohmann-json
+          brew install cmake ninja eigen ceres-solver nlohmann-json googletest
 
       # Set VCPKG vars
       - name: Set VCPKG_ROOT (Windows)
@@ -51,7 +51,7 @@ jobs:
         run: |
           if (-not (Test-Path $env:VCPKG_ROOT)) { git clone https://github.com/microsoft/vcpkg $env:VCPKG_ROOT }
           & "$env:VCPKG_ROOT\bootstrap-vcpkg.bat"
-          & "$env:VCPKG_ROOT\vcpkg.exe" install ceres eigen3 nlohmann-json --triplet $env:VCPKG_TRIPLET
+          & "$env:VCPKG_ROOT\vcpkg.exe" install ceres eigen3 nlohmann-json gtest --triplet $env:VCPKG_TRIPLET
       
       # Configure & Build for Linux/macOS
       - name: Configure (Unix)
@@ -64,6 +64,11 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           cmake --build "$BUILD_DIR" -j 2
+
+      - name: Run tests (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          ctest --test-dir "$BUILD_DIR" --output-on-failure
       
       # Configure & Build for Windows
       - name: Configure (Windows, MSVC + Ninja)
@@ -95,6 +100,12 @@ jobs:
 
           # Build with MSVC
           cmake --build "$env:BUILD_DIR" --config ${{ matrix.build_type }} -j 2
+
+      - name: Run tests (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          ctest --test-dir "$env:BUILD_DIR" --output-on-failure -C ${{ matrix.build_type }}
 
       # ---------- Smoke tests ----------
       - name: Run smoke test (Unix)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,17 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(Ceres CONFIG REQUIRED)
 find_package(Eigen3 CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
-
-# Add GTest
-include(FetchContent)
-FetchContent_Declare(
-    googletest
-    URL https://github.com/google/googletest/archive/refs/tags/v1.13.0.tar.gz
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-)
-# For Windows: Prevent overriding the parent project's compiler/linker settings
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
+find_package(GTest CONFIG REQUIRED)
 
 enable_testing()
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,22 @@ A C++ library for camera calibration and vision-related geometric transformation
 - Eigen3: Linear algebra library
 - Ceres: Non-linear optimization
 - nlohmann-json: JSON parsing and serialization
+- GoogleTest: Unit testing framework
 
 ## Installation
 
 ### Ubuntu
 
 ```bash
-sudo apt install libeigen3-dev libceres-dev nlohmann-json3-dev
+sudo apt install libeigen3-dev libceres-dev nlohmann-json3-dev libgtest-dev
+```
+
+### Windows
+
+Use [vcpkg](https://github.com/microsoft/vcpkg) to install the dependencies:
+
+```powershell
+vcpkg install ceres eigen3 nlohmann-json gtest
 ```
 
 ### Other platforms


### PR DESCRIPTION
## Summary
- switch to system-installed GoogleTest
- run unit tests in CI across platforms
- document gtest installation for Ubuntu and Windows

## Testing
- `sudo apt-get update` *(fails: repository not signed)*
- `cmake -S . -B build` *(fails: Could not find Ceres package)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f4bbcc688332aa9af02daabd6a0c