### PR TITLE
Ensure GoogleMock is available for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,14 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake ninja-build libeigen3-dev libceres-dev nlohmann-json3-dev
+          sudo apt-get install -y cmake ninja-build libeigen3-dev libceres-dev nlohmann-json3-dev libgtest-dev libgmock-dev
 
       # ---------- macOS deps ----------
       - name: Install deps (macOS)
         if: startsWith(matrix.os, 'macos')
         run: |
           brew update
-          brew install cmake ninja eigen ceres-solver nlohmann-json
+          brew install cmake ninja eigen ceres-solver nlohmann-json googletest
 
       # Set VCPKG vars
       - name: Set VCPKG_ROOT (Windows)
@@ -51,7 +51,7 @@ jobs:
         run: |
           if (-not (Test-Path $env:VCPKG_ROOT)) { git clone https://github.com/microsoft/vcpkg $env:VCPKG_ROOT }
           & "$env:VCPKG_ROOT\bootstrap-vcpkg.bat"
-          & "$env:VCPKG_ROOT\vcpkg.exe" install ceres eigen3 nlohmann-json --triplet $env:VCPKG_TRIPLET
+          & "$env:VCPKG_ROOT\vcpkg.exe" install ceres eigen3 nlohmann-json gtest --triplet $env:VCPKG_TRIPLET
       
       # Configure & Build for Linux/macOS
       - name: Configure (Unix)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,17 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(Ceres CONFIG REQUIRED)
 find_package(Eigen3 CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
-
-# Add GTest
-include(FetchContent)
-FetchContent_Declare(
-    googletest
-    URL https://github.com/google/googletest/archive/refs/tags/v1.13.0.tar.gz
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-)
-# For Windows: Prevent overriding the parent project's compiler/linker settings
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
+find_package(GTest CONFIG REQUIRED)
 
 enable_testing()
 

--- a/README.md
+++ b/README.md
@@ -17,14 +17,16 @@ A C++ library for camera calibration and vision-related geometric transformation
 - Eigen3: Linear algebra library
 - Ceres: Non-linear optimization
 - nlohmann-json: JSON parsing and serialization
+- GoogleTest & GoogleMock: Unit testing frameworks
 
 ## Installation
 
 ### Ubuntu
 
 ```bash
-sudo apt install libeigen3-dev libceres-dev nlohmann-json3-dev
+sudo apt install libeigen3-dev libceres-dev nlohmann-json3-dev libgtest-dev libgmock-dev
 ```
+These packages install both GoogleTest and GoogleMock, which are needed to build and run the unit tests.
 
 ### Other platforms
 


### PR DESCRIPTION
## Summary
- Install libgmock-dev and libgtest-dev in CI so GTest::gmock_main is available
- Document GoogleTest/GoogleMock as required Ubuntu packages
- Locate GTest with CMake instead of fetching a copy

## Testing
- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release` *(fails: Could not find a package configuration file provided by "Ceres")*

------
https://chatgpt.com/codex/tasks/task_e_68a5f75e3b0c8332b3495ef5815c788a