### PR TITLE
Use autodiff for intrinsics and planar pose residuals

### DIFF
--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -10,64 +10,69 @@
 
 namespace vitavision {
 
-// CostFunction that does variable projection and finite-difference Jacobians.
-class IntrinsicsVPResidual : public ceres::CostFunction {
-    void computeResiduals(const double intr[4], double* residuals) const {
-        Eigen::MatrixXd A;
-        Eigen::VectorXd b;
-        LSDesign::build(obs_, num_radial_, intr[0], intr[1], intr[2], intr[3], A, b);
-        Eigen::VectorXd alpha = LSDesign::solveNormal(A, b);
-
-        // Predicted minus observed = (u0 + A*alpha) - (u_obs, v_obs)  ==  A*alpha - b
-        Eigen::VectorXd r = A * alpha - b;
-        // Copy out
-        for (int i = 0; i < r.size(); ++i) residuals[i] = r[i];
-    }
-
+// Residual functor used with AutoDiffCostFunction. The functor performs
+// variable projection by solving a linear least squares problem for the
+// distortion coefficients for each set of intrinsics.
+struct IntrinsicsVPResidual {
     std::vector<Observation> obs_;
     int num_radial_;
 
-public:
     IntrinsicsVPResidual(std::vector<Observation> obs, int num_radial)
-        : obs_(std::move(obs)), num_radial_(num_radial)
-    {
-        set_num_residuals(static_cast<int>(obs_.size()) * 2);
-        // Single parameter block: [fx, fy, cx, cy]
-        mutable_parameter_block_sizes()->push_back(4);
-    }
+        : obs_(std::move(obs)), num_radial_(num_radial) {}
 
-    bool Evaluate(double const* const* parameters,
-                  double* residuals,
-                  double** jacobians) const override {
-        const double* intr = parameters[0];
-        computeResiduals(intr, residuals);
+    template <typename T>
+    bool operator()(const T* intr, T* residuals) const {
+        const int M = num_radial_ + 2;               // radial + tangential coeffs
+        const int rows = static_cast<int>(obs_.size()) * 2;
 
-        if (jacobians && jacobians[0]) {
-            // Central finite differences on intrinsics
-            double* J = jacobians[0];
-            const int m = num_residuals();
-            const double base[4] = {intr[0], intr[1], intr[2], intr[3]};
+        Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> A(rows, M);
+        Eigen::Matrix<T, Eigen::Dynamic, 1> b(rows);
 
-            std::vector<double> r_plus(m), r_minus(m);
-            for (int k = 0; k < 4; ++k) {
-                double step = 1e-6 * std::max(1.0, std::abs(base[k]));
-                double intr_p[4] = { base[0], base[1], base[2], base[3] };
-                double intr_m[4] = { base[0], base[1], base[2], base[3] };
-                intr_p[k] += step;
-                intr_m[k] -= step;
+        for (int i = 0, n = static_cast<int>(obs_.size()); i < n; ++i) {
+            const T x = T(obs_[i].x);
+            const T y = T(obs_[i].y);
+            const T r2 = x * x + y * y;
 
-                computeResiduals(intr_p, r_plus.data());
-                computeResiduals(intr_m, r_minus.data());
+            const T u0 = intr[0] * x + intr[2];
+            const T v0 = intr[1] * y + intr[3];
 
-                for (int i = 0; i < m; ++i) {
-                    J[i * 4 + k] = (r_plus[i] - r_minus[i]) / (2.0 * step);
-                }
+            const T du = T(obs_[i].u) - u0;
+            const T dv = T(obs_[i].v) - v0;
+
+            const int ru = 2 * i;
+            const int rv = ru + 1;
+
+            // Radial terms
+            T rpow = r2;  // r^(2*1)
+            for (int j = 0; j < num_radial_; ++j) {
+                A(ru, j) = intr[0] * x * rpow;
+                A(rv, j) = intr[1] * y * rpow;
+                rpow *= r2;
             }
+
+            // Tangential terms
+            const int idx_p1 = num_radial_;
+            const int idx_p2 = num_radial_ + 1;
+            A(ru, idx_p1) = intr[0] * (T(2.0) * x * y);
+            A(ru, idx_p2) = intr[0] * (r2 + T(2.0) * x * x);
+            A(rv, idx_p1) = intr[1] * (r2 + T(2.0) * y * y);
+            A(rv, idx_p2) = intr[1] * (T(2.0) * x * y);
+
+            b(ru) = du;
+            b(rv) = dv;
+        }
+
+        Eigen::Matrix<T, Eigen::Dynamic, 1> alpha =
+            (A.transpose() * A).ldlt().solve(A.transpose() * b);
+        Eigen::Matrix<T, Eigen::Dynamic, 1> r = A * alpha - b;
+        for (int i = 0; i < r.size(); ++i) {
+            residuals[i] = r[i];
         }
         return true;
     }
 
-    // Compute optimal distortion coeffs for given intrinsics (useful after Solve).
+    // Compute optimal distortion coeffs for given intrinsics (useful after
+    // Solve).  This is still used by the API after the optimization.
     Eigen::VectorXd SolveDistortionFor(const double intr[4]) const {
         return fit_distortion(obs_, intr[0], intr[1], intr[2], intr[3], num_radial_);
     }
@@ -75,7 +80,7 @@ public:
 
 static bool compute_covariance(
     size_t n_obs,
-    const IntrinsicsVPResidual& vp,
+    ceres::CostFunction& cost,
     double const* intrinsics,
     ceres::Problem& problem,
     IntrinsicOptimizationResult& result
@@ -84,9 +89,9 @@ static bool compute_covariance(
     const int m = static_cast<int>(n_obs) * 2;
     std::vector<double> residuals(2 * n_obs);
     
-    // Fix: Create parameter array for Evaluate
+    // Evaluate residuals at the optimum
     const double* params[1] = {intrinsics};
-    vp.Evaluate(params, residuals.data(), nullptr);
+    cost.Evaluate(params, residuals.data(), nullptr);
 
     double ssr = 0.0;
     for (double r : residuals) ssr += r * r;
@@ -128,13 +133,12 @@ IntrinsicOptimizationResult optimize_intrinsics(
     };
 
     ceres::Problem problem;
-    #if 0
-    auto costptr = std::make_unique<IntrinsicsVPResidual>(obs, num_radial);
-    #else
-    auto costptr = new IntrinsicsVPResidual(obs, num_radial);
-    #endif
+    auto* functor = new IntrinsicsVPResidual(obs, num_radial);
+    auto* cost = new ceres::AutoDiffCostFunction<IntrinsicsVPResidual,
+                                                 ceres::DYNAMIC, 4>(functor,
+                                                                      static_cast<int>(obs.size()) * 2);
 
-    problem.AddResidualBlock(costptr, /*loss=*/nullptr, intrinsics);
+    problem.AddResidualBlock(cost, /*loss=*/nullptr, intrinsics);
 
     ceres::Solver::Options options;
     options.linear_solver_type = ceres::DENSE_QR;
@@ -154,9 +158,9 @@ IntrinsicOptimizationResult optimize_intrinsics(
     result.distortion = fit_distortion(
         obs, intrinsics[0], intrinsics[1], intrinsics[2], intrinsics[3], num_radial);
     result.summary = summary.BriefReport();
-    
-    // Fix: Pass the cost function object reference instead of intrinsics array
-    if (!compute_covariance(obs.size(), *costptr, intrinsics, problem, result)) {
+
+    // Compute covariance using the optimized cost function
+    if (!compute_covariance(obs.size(), *cost, intrinsics, problem, result)) {
         std::cerr << "Covariance computation failed.\n";
     }
 


### PR DESCRIPTION
## Summary
- Refactor intrinsics variable projection residual into an AutoDiff-friendly functor and remove manual finite difference Jacobians.
- Apply the same AutoDiff conversion to planar pose variable projection residuals.
- Add gradient parity tests verifying AutoDiff Jacobians against finite differences for intrinsics and planar pose.

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Ceres"...)*
- `apt-get update` *(fails: repository InRelease 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6aacacafc83328b753aad978921c1