### PR TITLE
Add linear intrinsics initializer for optimization

### DIFF
--- a/include/calibration/intrinsics.h
+++ b/include/calibration/intrinsics.h
@@ -28,6 +28,15 @@ struct IntrinsicOptimizationResult {
     std::string summary;         // Summary of optimization results
 };
 
+// Estimate camera intrinsics (fx, fy, cx, cy) by solving a linear
+// least-squares system that ignores lens distortion.  The input
+// observations contain normalized coordinates (x,y) for an undistorted
+// point and the observed pixel coordinates (u,v).  The function returns
+// an optional CameraMatrix: std::nullopt is returned if there are not
+// enough observations or the linear system is degenerate.
+std::optional<CameraMatrix> estimate_intrinsics_linear(
+    const std::vector<Observation<double>>& obs);
+
 IntrinsicOptimizationResult optimize_intrinsics(
     const std::vector<Observation<double>>& obs,
     int num_radial,


### PR DESCRIPTION
## Summary
- implement `estimate_intrinsics_linear` to compute camera intrinsics from correspondences
- expose new API and use it in tests

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Ceres")*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6eedeaf288332be52c6b7c95d0f76