### PR TITLE
Add planar multi-view camera calibration

### DIFF
--- a/include/calibration/calib.h
+++ b/include/calibration/calib.h
@@ -1,0 +1,39 @@
+#pragma once
+
+/** @brief Full single camera calibration from multiple planar views */
+
+// std
+#include <vector>
+#include <string>
+
+// eigen
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include "calibration/intrinsics.h"
+
+namespace vitavision {
+
+struct PlanarView {
+    std::vector<Eigen::Vector2d> object_xy;  // Planar target coordinates (Z=0)
+    std::vector<Eigen::Vector2d> image_uv;   // Corresponding pixel measurements
+};
+
+struct CameraCalibrationResult {
+    CameraMatrix intrinsics;                     // Estimated camera matrix
+    Eigen::VectorXd distortion;                  // Distortion coefficients [k..., p1, p2]
+    std::vector<Eigen::Affine3d> poses;          // Poses of each view (world->camera)
+    Eigen::MatrixXd covariance;                  // Covariance of intrinsics and poses
+    std::vector<double> view_errors;             // Reprojection RMSE for each view
+    double reprojection_error;                   // Overall reprojection RMSE
+    std::string summary;                         // Solver brief report
+};
+
+CameraCalibrationResult calibrate_camera_planar(
+    const std::vector<PlanarView>& views,
+    int num_radial,
+    const CameraMatrix& initial_guess,
+    bool verbose = false);
+
+}  // namespace vitavision
+

--- a/src/calib.cpp
+++ b/src/calib.cpp
@@ -1,0 +1,214 @@
+#include "calibration/calib.h"
+
+// std
+#include <numeric>
+
+// ceres
+#include <ceres/ceres.h>
+#include <ceres/rotation.h>
+
+#include "calibration/distortion.h"
+#include "calibration/planarpose.h"  // for estimate_planar_pose_dlt
+
+namespace vitavision {
+
+struct CalibObs { Eigen::Vector2d XY; Eigen::Vector2d uv; };
+using Pose6 = Eigen::Matrix<double,6,1>;
+
+// Variable projection residual for full camera calibration.
+struct CalibVPResidual {
+    std::vector<std::vector<CalibObs>> views_; // observations per view
+    int num_radial_;
+    size_t total_obs_;
+
+    CalibVPResidual(std::vector<std::vector<CalibObs>> views, int num_radial)
+        : views_(std::move(views)), num_radial_(num_radial) {
+        total_obs_ = 0;
+        for (const auto& v : views_) total_obs_ += v.size();
+    }
+
+    template<typename T>
+    bool operator()(T const* const* params, T* residuals) const {
+        const T* intr = params[0];
+        std::vector<Observation<T>> obs;
+        obs.reserve(total_obs_);
+        for (size_t i = 0; i < views_.size(); ++i) {
+            const T* pose6 = params[1 + i];
+            for (const auto& ob : views_[i]) {
+                Eigen::Matrix<T,3,1> P(T(ob.XY.x()), T(ob.XY.y()), T(0.0));
+                Eigen::Matrix<T,3,1> Pc;
+                ceres::AngleAxisRotatePoint(pose6, P.data(), Pc.data());
+                Pc += Eigen::Matrix<T,3,1>(pose6[3], pose6[4], pose6[5]);
+                T invZ = T(1.0) / Pc.z();
+                Observation<T> o;
+                o.x = Pc.x() * invZ;
+                o.y = Pc.y() * invZ;
+                o.u = T(ob.uv.x());
+                o.v = T(ob.uv.y());
+                obs.push_back(o);
+            }
+        }
+        auto [_, r] = fit_distortion_full(obs, intr[0], intr[1], intr[2], intr[3], num_radial_);
+        for (int i = 0; i < r.size(); ++i) residuals[i] = r[i];
+        return true;
+    }
+
+    DistortionWithResiduals<double> SolveFull(const double* intr, const std::vector<const double*>& pose_ptrs) const {
+        std::vector<Observation<double>> obs;
+        obs.reserve(total_obs_);
+        for (size_t i = 0; i < views_.size(); ++i) {
+            const double* pose6 = pose_ptrs[i];
+            for (const auto& ob : views_[i]) {
+                Eigen::Vector3d P(ob.XY.x(), ob.XY.y(), 0.0);
+                Eigen::Vector3d Pc;
+                ceres::AngleAxisRotatePoint(pose6, P.data(), Pc.data());
+                Pc += Eigen::Vector3d(pose6[3], pose6[4], pose6[5]);
+                double invZ = 1.0 / Pc.z();
+                Observation<double> o;
+                o.x = Pc.x() * invZ;
+                o.y = Pc.y() * invZ;
+                o.u = ob.uv.x();
+                o.v = ob.uv.y();
+                obs.push_back(o);
+            }
+        }
+        return fit_distortion_full(obs, intr[0], intr[1], intr[2], intr[3], num_radial_);
+    }
+};
+
+static Eigen::Affine3d axisangle_to_pose(const Pose6& pose6) {
+    Eigen::Matrix3d R;
+    ceres::AngleAxisToRotationMatrix(pose6.head<3>().data(), R.data());
+    Eigen::Affine3d T = Eigen::Affine3d::Identity();
+    T.linear() = R;
+    T.translation() = pose6.tail<3>();
+    return T;
+}
+
+CameraCalibrationResult calibrate_camera_planar(
+    const std::vector<PlanarView>& views,
+    int num_radial,
+    const CameraMatrix& initial_guess,
+    bool verbose) {
+    CameraCalibrationResult result;
+    const size_t V = views.size();
+    if (V == 0) return result;
+
+    // Prepare observations per view
+    std::vector<std::vector<CalibObs>> obs_views(V);
+    size_t total_obs = 0;
+    for (size_t i = 0; i < V; ++i) {
+        const auto& obj = views[i].object_xy;
+        const auto& img = views[i].image_uv;
+        size_t n = std::min(obj.size(), img.size());
+        obs_views[i].reserve(n);
+        for (size_t j = 0; j < n; ++j) {
+            obs_views[i].push_back({obj[j], img[j]});
+        }
+        total_obs += n;
+    }
+
+    double intr[4] = {initial_guess.fx, initial_guess.fy, initial_guess.cx, initial_guess.cy};
+    std::vector<Pose6> poses(V);
+    for (size_t i = 0; i < V; ++i) {
+        Eigen::Affine3d pose = estimate_planar_pose_dlt(views[i].object_xy, views[i].image_uv, initial_guess);
+        ceres::RotationMatrixToAngleAxis(pose.linear().data(), poses[i].data());
+        poses[i][3] = pose.translation().x();
+        poses[i][4] = pose.translation().y();
+        poses[i][5] = pose.translation().z();
+    }
+
+    auto* functor = new CalibVPResidual(obs_views, num_radial);
+    auto* cost = new ceres::DynamicAutoDiffCostFunction<CalibVPResidual>(functor);
+    cost->AddParameterBlock(4);
+    for (size_t i = 0; i < V; ++i) cost->AddParameterBlock(6);
+    cost->SetNumResiduals(static_cast<int>(total_obs * 2));
+
+    ceres::Problem problem;
+    std::vector<double*> param_blocks;
+    param_blocks.push_back(intr);
+    for (size_t i = 0; i < V; ++i) param_blocks.push_back(poses[i].data());
+    problem.AddResidualBlock(cost, nullptr, param_blocks);
+
+    ceres::Solver::Options opts;
+    opts.linear_solver_type = ceres::DENSE_QR;
+    opts.minimizer_progress_to_stdout = verbose;
+    opts.function_tolerance = 1e-12;
+    opts.gradient_tolerance = 1e-12;
+    opts.parameter_tolerance = 1e-12;
+
+    ceres::Solver::Summary summary;
+    ceres::Solve(opts, &problem, &summary);
+    result.summary = summary.BriefReport();
+
+    // Compute best distortion and residuals
+    std::vector<const double*> pose_ptrs(V);
+    for (size_t i = 0; i < V; ++i) pose_ptrs[i] = poses[i].data();
+    auto dr = functor->SolveFull(intr, pose_ptrs);
+    result.distortion = dr.distortion;
+
+    // Reprojection errors
+    int m = static_cast<int>(total_obs * 2);
+    double ssr = dr.residuals.squaredNorm();
+    result.reprojection_error = std::sqrt(ssr / m);
+    result.view_errors.resize(V);
+    int idx = 0;
+    for (size_t i = 0; i < V; ++i) {
+        int ni = static_cast<int>(obs_views[i].size());
+        double s = 0.0;
+        for (int j = 0; j < ni * 2; ++j) {
+            double r = dr.residuals[idx++];
+            s += r * r;
+        }
+        result.view_errors[i] = std::sqrt(s / (ni * 2));
+    }
+
+    // Populate outputs
+    result.intrinsics.fx = intr[0];
+    result.intrinsics.fy = intr[1];
+    result.intrinsics.cx = intr[2];
+    result.intrinsics.cy = intr[3];
+    result.poses.resize(V);
+    for (size_t i = 0; i < V; ++i) result.poses[i] = axisangle_to_pose(poses[i]);
+
+    // Covariance computation
+    const size_t total_params = 4 + 6 * V;
+    std::vector<const double*> blocks = param_blocks;
+    std::vector<int> block_sizes; block_sizes.push_back(4); for (size_t i=0;i<V;++i) block_sizes.push_back(6);
+    ceres::Covariance::Options copt;
+    ceres::Covariance cov(copt);
+    std::vector<std::pair<const double*, const double*>> cov_blocks;
+    for (size_t i = 0; i < blocks.size(); ++i)
+        for (size_t j = 0; j <= i; ++j)
+            cov_blocks.emplace_back(blocks[i], blocks[j]);
+
+    if (cov.Compute(cov_blocks, &problem)) {
+        Eigen::MatrixXd C = Eigen::MatrixXd::Zero(total_params, total_params);
+        size_t oi = 0;
+        for (size_t i = 0; i < blocks.size(); ++i) {
+            int si = block_sizes[i];
+            size_t oj = 0;
+            for (size_t j = 0; j <= i; ++j) {
+                int sj = block_sizes[j];
+                std::vector<double> tmp(si * sj);
+                cov.GetCovarianceBlock(blocks[i], blocks[j], tmp.data());
+                for (int r = 0; r < si; ++r)
+                    for (int c = 0; c < sj; ++c) {
+                        C(oi + r, oj + c) = tmp[r * sj + c];
+                        if (j < i) C(oj + c, oi + r) = tmp[r * sj + c];
+                    }
+                oj += sj;
+            }
+            oi += si;
+        }
+        int dof = std::max(1, m - static_cast<int>(total_params));
+        double sigma2 = ssr / dof;
+        C *= sigma2;
+        result.covariance = C;
+    }
+
+    return result;
+}
+
+} // namespace vitavision
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,3 +41,15 @@ target_link_libraries(planarpose_test PRIVATE
     Ceres::ceres
 )
 gtest_discover_tests(planarpose_test)
+
+# Test for full camera calibration
+add_executable(calib_test calib_test.cpp)
+target_link_libraries(calib_test
+    PRIVATE calibration
+    PRIVATE GTest::gtest_main
+    PRIVATE GTest::gmock_main
+    PRIVATE Eigen3::Eigen
+    PRIVATE Ceres::ceres
+)
+gtest_discover_tests(calib_test)
+

--- a/test/calib_test.cpp
+++ b/test/calib_test.cpp
@@ -1,0 +1,83 @@
+#include "calibration/calib.h"
+
+// std
+#include <random>
+
+// gtest
+#include <gtest/gtest.h>
+
+using namespace vitavision;
+
+namespace {
+
+static void distort_and_project(const Eigen::Vector3d& P,
+                                const Eigen::Affine3d& pose,
+                                const CameraMatrix& intr,
+                                const std::vector<double>& k_radial,
+                                double p1, double p2,
+                                Eigen::Vector2d& uv) {
+    Eigen::Vector3d Pc = pose * P;
+    double x = Pc.x() / Pc.z();
+    double y = Pc.y() / Pc.z();
+    double r2 = x*x + y*y;
+    double radial = 1.0;
+    double rpow = r2;
+    for (double k : k_radial) { radial += k * rpow; rpow *= r2; }
+    double x_t = x * radial + 2.0 * p1 * x * y + p2 * (r2 + 2.0 * x * x);
+    double y_t = y * radial + p1 * (r2 + 2.0 * y * y) + 2.0 * p2 * x * y;
+    uv.x() = intr.fx * x_t + intr.cx;
+    uv.y() = intr.fy * y_t + intr.cy;
+}
+
+} // namespace
+
+TEST(CameraCalibrationTest, PlanarViewsExact) {
+    CameraMatrix intr_true{800.0, 820.0, 640.0, 360.0};
+    std::vector<double> k_rad = {-0.20, 0.03};
+    double p1 = 0.001, p2 = -0.0005;
+
+    // Planar grid points
+    std::vector<Eigen::Vector2d> obj_xy;
+    for (int i=-5;i<=5;i+=2)
+        for (int j=-5;j<=5;j+=2)
+            obj_xy.emplace_back(0.04*i, 0.04*j);
+
+    // Generate several poses
+    std::vector<PlanarView> views(3);
+    std::vector<Eigen::Affine3d> poses_true(3);
+    poses_true[0] = Eigen::Affine3d::Identity();
+    poses_true[0].translation() = Eigen::Vector3d(0.1, -0.1, 2.0);
+    poses_true[1] = Eigen::Affine3d::Identity();
+    poses_true[1].linear() = Eigen::AngleAxisd(0.2, Eigen::Vector3d::UnitY()).toRotationMatrix();
+    poses_true[1].translation() = Eigen::Vector3d(-0.2, 0.1, 1.8);
+    poses_true[2] = Eigen::Affine3d::Identity();
+    poses_true[2].linear() = Eigen::AngleAxisd(-0.15, Eigen::Vector3d::UnitX()).toRotationMatrix();
+    poses_true[2].translation() = Eigen::Vector3d(0.05, 0.2, 2.2);
+
+    for (size_t v=0; v<views.size(); ++v) {
+        views[v].object_xy = obj_xy;
+        views[v].image_uv.resize(obj_xy.size());
+        for (size_t i=0;i<obj_xy.size();++i) {
+            Eigen::Vector3d P(obj_xy[i].x(), obj_xy[i].y(), 0.0);
+            distort_and_project(P, poses_true[v], intr_true, k_rad, p1, p2, views[v].image_uv[i]);
+        }
+    }
+
+    CameraMatrix guess{780.0, 800.0, 630.0, 350.0};
+    auto res = calibrate_camera_planar(views, 2, guess, false);
+
+    EXPECT_NEAR(res.intrinsics.fx, intr_true.fx, 1e-6);
+    EXPECT_NEAR(res.intrinsics.fy, intr_true.fy, 1e-6);
+    EXPECT_NEAR(res.intrinsics.cx, intr_true.cx, 1e-6);
+    EXPECT_NEAR(res.intrinsics.cy, intr_true.cy, 1e-6);
+
+    EXPECT_NEAR(res.distortion[0], k_rad[0], 1e-6);
+    EXPECT_NEAR(res.distortion[1], k_rad[1], 1e-6);
+    EXPECT_NEAR(res.distortion[2], p1, 1e-6);
+    EXPECT_NEAR(res.distortion[3], p2, 1e-6);
+
+    EXPECT_EQ(res.view_errors.size(), views.size());
+    for (double e : res.view_errors) EXPECT_NEAR(e, 0.0, 1e-9);
+    EXPECT_NEAR(res.reprojection_error, 0.0, 1e-9);
+}
+


### PR DESCRIPTION
## Summary
- implement full camera calibration from multiple planar views with auto-diff and covariance estimation
- expose calibration API and result structures
- add unit test for planar view calibration

## Testing
- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release` *(failed: Could not find a package configuration file provided by "Ceres")*
- `apt-get update` *(failed: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f5e3666483328c7715a0804e49ce