### PR TITLE
Return optional from distortion fitting

### DIFF
--- a/include/calibration/distortion.h
+++ b/include/calibration/distortion.h
@@ -3,6 +3,7 @@
 #pragma once
 
 // std
+#include <optional>
 #include <vector>
 
 // eigen
@@ -27,17 +28,13 @@ struct DistortionWithResiduals {
 };
 
 template<typename T>
-DistortionWithResiduals<T> fit_distortion_full(
+std::optional<DistortionWithResiduals<T>> fit_distortion_full(
     const std::vector<Observation<T>>& obs,
     T fx, T fy, T cx, T cy,
     int num_radial = 2
 ) {
     if (obs.size() < 8) {
-        // Return empty result instead of throwing exception
-        // This is safer with automatic differentiation
-        Eigen::Matrix<T, Eigen::Dynamic, 1> empty_vec(1);
-        empty_vec(0) = T(0);
-        return {empty_vec, empty_vec};
+        return std::nullopt;
     }
 
     const int M = num_radial + 2;  // radial + tangential coeffs
@@ -97,16 +94,16 @@ DistortionWithResiduals<T> fit_distortion_full(
 
     Eigen::Matrix<T, Eigen::Dynamic, 1> r = A * alpha - b;
 
-    return {alpha, r};
+    return DistortionWithResiduals<T>{alpha, r};
 }
 
 template<typename T>
-Eigen::VectorXd fit_distortion(
+std::optional<DistortionWithResiduals<T>> fit_distortion(
     const std::vector<Observation<T>>& obs,
     T fx, T fy, T cx, T cy,
     int num_radial = 2
 ) {
-    return fit_distortion_full(obs, fx, fy, cx, cy, num_radial).distortion;
+    return fit_distortion_full(obs, fx, fy, cx, cy, num_radial);
 }
 
 }  // namespace vitavision

--- a/test/distortion_test.cpp
+++ b/test/distortion_test.cpp
@@ -93,7 +93,9 @@ TEST(DistortionTest, ExactFit) {
         k_true, p1_true, p2_true, fx, fy, cx, cy, 500, 0.0);
     
     // Fit distortion parameters
-    Eigen::VectorXd distortion = fit_distortion(observations, fx, fy, cx, cy, 2);
+    auto distortion_opt = fit_distortion(observations, fx, fy, cx, cy, 2);
+    ASSERT_TRUE(distortion_opt.has_value());
+    Eigen::VectorXd distortion = distortion_opt->distortion;
     
     // Check results
     EXPECT_NEAR(distortion[0], k_true[0], 1e-10);
@@ -115,7 +117,9 @@ TEST(DistortionTest, NoisyFit) {
         k_true, p1_true, p2_true, fx, fy, cx, cy, 1000, 0.5);
     
     // Fit distortion parameters
-    Eigen::VectorXd distortion = fit_distortion(observations, fx, fy, cx, cy, 2);
+    auto distortion_opt = fit_distortion(observations, fx, fy, cx, cy, 2);
+    ASSERT_TRUE(distortion_opt.has_value());
+    Eigen::VectorXd distortion = distortion_opt->distortion;
     
     // Results should be close but not exact due to noise
     EXPECT_NEAR(distortion[0], k_true[0], 0.01);

--- a/test/intrinsics_test.cpp
+++ b/test/intrinsics_test.cpp
@@ -92,8 +92,12 @@ struct IntrinsicsVPResidualTestFunctor {
             return Observation<T>{static_cast<T>(obs.x), static_cast<T>(obs.y),
                                   static_cast<T>(obs.u), static_cast<T>(obs.v)};
         });
-        auto [_, r] = fit_distortion_full(
+        auto dr = fit_distortion_full(
             o, intr[0], intr[1], intr[2], intr[3], num_radial);
+        if (!dr) {
+            return false;
+        }
+        const auto& r = dr->residuals;
         for (int i = 0; i < r.size(); ++i) residuals[i] = r[i];
         return true;
     }

--- a/test/planarpose_test.cpp
+++ b/test/planarpose_test.cpp
@@ -79,7 +79,11 @@ struct PlanarPoseVPResidualTestFunctor {
         const T fy = T(K[1]);
         const T cx = T(K[2]);
         const T cy = T(K[3]);
-        auto [_, r] = fit_distortion_full(o, fx, fy, cx, cy, num_radial);
+        auto dr = fit_distortion_full(o, fx, fy, cx, cy, num_radial);
+        if (!dr) {
+            return false;
+        }
+        const auto& r = dr->residuals;
         for (int i = 0; i < r.size(); ++i) {
             residuals[i] = r[i];
         }


### PR DESCRIPTION
## Summary
- return `std::optional<DistortionWithResiduals>` from `fit_distortion_full` and `fit_distortion`
- handle missing data by returning `std::nullopt` and checking results in intrinsics, planar pose, and calibration callers
- adjust unit tests for the new optional-based API

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Ceres")*


------
https://chatgpt.com/codex/tasks/task_e_68a751f67c108332a38cb97154a4bba8