### PR TITLE
Add joint calibration routines and tests

### DIFF
--- a/include/calibration/extrinsics.h
+++ b/include/calibration/extrinsics.h
@@ -26,6 +26,33 @@ struct ExtrinsicOptimizationResult final {
     std::string summary;                         // Solver brief report
 };
 
+struct InitialExtrinsicGuess final {
+    std::vector<Eigen::Affine3d> camera_poses;  // reference->camera
+    std::vector<Eigen::Affine3d> target_poses;  // target->reference
+};
+
+struct JointOptimizationResult final {
+    std::vector<CameraMatrix> intrinsics;                       // Optimized camera matrices
+    std::vector<Eigen::Affine3d> camera_poses;                  // reference->camera
+    std::vector<Eigen::Affine3d> target_poses;                  // target->reference
+    std::vector<Eigen::Matrix4d> intrinsic_covariances;         // Covariance of intrinsics
+    std::vector<Eigen::Matrix<double,6,6>> camera_covariances;  // Covariance of camera poses
+    std::vector<Eigen::Matrix<double,6,6>> target_covariances;  // Covariance of target poses
+    double reprojection_error = 0.0;                            // RMS pixel error
+    std::string summary;                                        // Solver brief report
+};
+
+InitialExtrinsicGuess make_initial_extrinsic_guess(
+    const std::vector<ExtrinsicPlanarView>& views,
+    const std::vector<Camera>& cameras);
+
+JointOptimizationResult optimize_joint_intrinsics_extrinsics(
+    const std::vector<ExtrinsicPlanarView>& views,
+    const std::vector<Camera>& initial_cameras,
+    const std::vector<Eigen::Affine3d>& initial_camera_poses,
+    const std::vector<Eigen::Affine3d>& initial_target_poses,
+    bool verbose = false);
+
 ExtrinsicOptimizationResult optimize_extrinsic_poses(
     const std::vector<ExtrinsicPlanarView>& views,
     const std::vector<Camera>& cameras,

--- a/src/extrinsics.cpp
+++ b/src/extrinsics.cpp
@@ -2,6 +2,8 @@
 
 // std
 #include <numeric>
+#include <algorithm>
+#include <array>
 
 // ceres
 #include <ceres/ceres.h>
@@ -10,6 +12,86 @@
 namespace vitavision {
 
 using Pose6 = Eigen::Matrix<double, 6, 1>;
+
+// Utility: average a set of affine transforms (rotation via quaternion averaging)
+static Eigen::Affine3d average_affines(const std::vector<Eigen::Affine3d>& poses) {
+    if (poses.empty()) return Eigen::Affine3d::Identity();
+    Eigen::Vector3d t = Eigen::Vector3d::Zero();
+    Eigen::Quaterniond q_sum(0,0,0,0);
+    for (const auto& p : poses) {
+        t += p.translation();
+        Eigen::Quaterniond q(p.linear());
+        if (q_sum.coeffs().dot(q.coeffs()) < 0.0) q.coeffs() *= -1.0;
+        q_sum.coeffs() += q.coeffs();
+    }
+    t /= static_cast<double>(poses.size());
+    q_sum.normalize();
+    Eigen::Affine3d avg = Eigen::Affine3d::Identity();
+    avg.linear() = q_sum.toRotationMatrix();
+    avg.translation() = t;
+    return avg;
+}
+
+InitialExtrinsicGuess make_initial_extrinsic_guess(
+    const std::vector<ExtrinsicPlanarView>& views,
+    const std::vector<Camera>& cameras) {
+    const size_t num_cams = cameras.size();
+    const size_t num_views = views.size();
+    std::vector<std::vector<Eigen::Affine3d>> cam_to_target(num_views, std::vector<Eigen::Affine3d>(num_cams, Eigen::Affine3d::Identity()));
+
+    // Estimate per-camera target poses via DLT
+    for (size_t v = 0; v < num_views; ++v) {
+        for (size_t c = 0; c < num_cams; ++c) {
+            const auto& obs = views[v].observations;
+            if (c >= obs.size()) continue;
+            const auto& ob_c = obs[c];
+            if (ob_c.size() < 4) continue;
+            std::vector<Eigen::Vector2d> obj_xy, img_uv;
+            obj_xy.reserve(ob_c.size());
+            img_uv.reserve(ob_c.size());
+            for (const auto& o : ob_c) {
+                obj_xy.push_back(o.object_xy);
+                img_uv.push_back(o.image_uv);
+            }
+            cam_to_target[v][c] = estimate_planar_pose_dlt(obj_xy, img_uv, cameras[c].intrinsics);
+        }
+    }
+
+    InitialExtrinsicGuess guess;
+    guess.camera_poses.assign(num_cams, Eigen::Affine3d::Identity());
+    guess.target_poses.assign(num_views, Eigen::Affine3d::Identity());
+
+    // Compute camera poses relative to first camera (reference)
+    for (size_t c = 1; c < num_cams; ++c) {
+        std::vector<Eigen::Affine3d> rels;
+        for (size_t v = 0; v < num_views; ++v) {
+            if (c >= views[v].observations.size()) continue;
+            const auto& obs0 = views[v].observations[0];
+            const auto& obsC = views[v].observations[c];
+            if (obs0.size() < 4 || obsC.size() < 4) continue;
+            rels.push_back(cam_to_target[v][c] * cam_to_target[v][0].inverse());
+        }
+        if (!rels.empty()) {
+            guess.camera_poses[c] = average_affines(rels);
+        }
+    }
+
+    // Compute target poses in reference frame
+    for (size_t v = 0; v < num_views; ++v) {
+        std::vector<Eigen::Affine3d> tposes;
+        for (size_t c = 0; c < num_cams; ++c) {
+            if (c >= views[v].observations.size()) continue;
+            const auto& ob_c = views[v].observations[c];
+            if (ob_c.size() < 4) continue;
+            tposes.push_back(guess.camera_poses[c].inverse() * cam_to_target[v][c]);
+        }
+        if (!tposes.empty()) {
+            guess.target_poses[v] = average_affines(tposes);
+        }
+    }
+
+    return guess;
+}
 
 struct ExtrinsicResidual {
     std::vector<PlanarObservation> obs_;
@@ -40,6 +122,46 @@ struct ExtrinsicResidual {
             auto uv = cam_.project_normalized(xyn);
             residuals[2*i]   = uv.x() - T(ob.image_uv.x());
             residuals[2*i+1] = uv.y() - T(ob.image_uv.y());
+        }
+        return true;
+    }
+};
+
+struct JointResidual {
+    std::vector<PlanarObservation> obs_;
+    Eigen::VectorXd distortion_;
+
+    JointResidual(std::vector<PlanarObservation> obs, const Eigen::VectorXd& dist)
+        : obs_(std::move(obs)), distortion_(dist) {}
+
+    template <typename T>
+    bool operator()(const T* intr, const T* cam_pose6, const T* target_pose6, T* residuals) const {
+        Eigen::Matrix<T,3,3> R_cam, R_target;
+        ceres::AngleAxisToRotationMatrix(cam_pose6, R_cam.data());
+        ceres::AngleAxisToRotationMatrix(target_pose6, R_target.data());
+        Eigen::Matrix<T,3,1> t_cam{cam_pose6[3], cam_pose6[4], cam_pose6[5]};
+        Eigen::Matrix<T,3,1> t_target{target_pose6[3], target_pose6[4], target_pose6[5]};
+
+        Eigen::Matrix<T,3,3> R = R_cam * R_target;
+        Eigen::Matrix<T,3,1> t = R_cam * t_target + t_cam;
+
+        const int N = static_cast<int>(obs_.size());
+        for (int i = 0; i < N; ++i) {
+            const auto& ob = obs_[i];
+            Eigen::Matrix<T,3,1> P{T(ob.object_xy.x()), T(ob.object_xy.y()), T(0)};
+            Eigen::Matrix<T,3,1> Pc = R * P + t;
+            T xn = Pc.x() / Pc.z();
+            T yn = Pc.y() / Pc.z();
+            Eigen::Matrix<T,2,1> xyn{xn, yn};
+            Eigen::Matrix<T,2,1> d = apply_distortion(xyn, distortion_);
+            T fx = intr[0];
+            T fy = intr[1];
+            T cx = intr[2];
+            T cy = intr[3];
+            T u = fx * d.x() + cx;
+            T v = fy * d.y() + cy;
+            residuals[2*i]   = u - T(ob.image_uv.x());
+            residuals[2*i+1] = v - T(ob.image_uv.y());
         }
         return true;
     }
@@ -236,6 +358,153 @@ ExtrinsicOptimizationResult optimize_extrinsic_poses(
     const double sigma2 = ssr / dof;
 
     compute_covariances(problem, cam_poses, targ_poses, sigma2, result);
+
+    return result;
+}
+
+// Joint optimization of camera intrinsics, extrinsic poses and target poses
+JointOptimizationResult optimize_joint_intrinsics_extrinsics(
+    const std::vector<ExtrinsicPlanarView>& views,
+    const std::vector<Camera>& initial_cameras,
+    const std::vector<Eigen::Affine3d>& initial_camera_poses,
+    const std::vector<Eigen::Affine3d>& initial_target_poses,
+    bool verbose) {
+    JointOptimizationResult result;
+    const size_t num_cams = initial_cameras.size();
+    const size_t num_views = views.size();
+    if (initial_camera_poses.size() != num_cams ||
+        initial_target_poses.size() != num_views) {
+        throw std::invalid_argument("Incompatible pose vector sizes for joint optimization");
+    }
+
+    // Parameter arrays
+    std::vector<std::array<double,4>> intr(num_cams);
+    for (size_t i = 0; i < num_cams; ++i) {
+        intr[i] = {initial_cameras[i].intrinsics.fx,
+                   initial_cameras[i].intrinsics.fy,
+                   initial_cameras[i].intrinsics.cx,
+                   initial_cameras[i].intrinsics.cy};
+    }
+    std::vector<Pose6> cam_poses(num_cams);
+    std::vector<Pose6> targ_poses(num_views);
+    initialize_pose_vectors(initial_camera_poses, initial_target_poses, cam_poses, targ_poses);
+
+    ceres::Problem problem;
+    for (size_t i = 0; i < num_cams; ++i) {
+        problem.AddParameterBlock(intr[i].data(), 4);
+        problem.AddParameterBlock(cam_poses[i].data(), 6);
+    }
+    if (!cam_poses.empty()) {
+        problem.SetParameterBlockConstant(cam_poses[0].data());
+    }
+    for (size_t v = 0; v < num_views; ++v) {
+        problem.AddParameterBlock(targ_poses[v].data(), 6);
+    }
+
+    // Residuals
+    for (size_t v = 0; v < num_views; ++v) {
+        const auto& view = views[v];
+        for (size_t c = 0; c < num_cams && c < view.observations.size(); ++c) {
+            const auto& obs = view.observations[c];
+            if (obs.empty()) continue;
+            auto* functor = new JointResidual(obs, initial_cameras[c].distortion);
+            auto* cost = new ceres::AutoDiffCostFunction<JointResidual,
+                                                         ceres::DYNAMIC,
+                                                         4,6,6>(functor,
+                                                                static_cast<int>(obs.size())*2);
+            problem.AddResidualBlock(cost, nullptr,
+                                     intr[c].data(), cam_poses[c].data(), targ_poses[v].data());
+        }
+    }
+
+    ceres::Solver::Options opts;
+    opts.linear_solver_type = ceres::DENSE_QR;
+    opts.minimizer_progress_to_stdout = verbose;
+    constexpr double eps = 1e-6;
+    opts.function_tolerance = eps;
+    opts.gradient_tolerance = eps;
+    opts.parameter_tolerance = eps;
+    opts.max_num_iterations = 1000;
+
+    ceres::Solver::Summary summary;
+    ceres::Solve(opts, &problem, &summary);
+    result.summary = summary.BriefReport();
+
+    // Extract solution
+    result.intrinsics.resize(num_cams);
+    result.camera_poses.resize(num_cams);
+    for (size_t i = 0; i < num_cams; ++i) {
+        result.intrinsics[i] = {intr[i][0], intr[i][1], intr[i][2], intr[i][3]};
+        result.camera_poses[i] = pose6_to_affine(cam_poses[i]);
+    }
+    result.target_poses.resize(num_views);
+    for (size_t v = 0; v < num_views; ++v) {
+        result.target_poses[v] = pose6_to_affine(targ_poses[v]);
+    }
+
+    // Residual statistics
+    double ssr = 0.0; size_t count = 0;
+    for (size_t v = 0; v < num_views; ++v) {
+        const auto& view = views[v];
+        for (size_t c = 0; c < num_cams && c < view.observations.size(); ++c) {
+            const auto& obs = view.observations[c];
+            for (const auto& ob : obs) {
+                Eigen::Vector3d P = result.camera_poses[c] * result.target_poses[v]
+                                    * Eigen::Vector3d(ob.object_xy.x(), ob.object_xy.y(), 0.0);
+                Eigen::Vector2d xyn{P.x()/P.z(), P.y()/P.z()};
+                Eigen::Vector2d d = apply_distortion(xyn, initial_cameras[c].distortion);
+                Eigen::Vector2d pred = result.intrinsics[c].denormalize(d);
+                Eigen::Vector2d diff = pred - ob.image_uv;
+                ssr += diff.squaredNorm();
+                count += 2;
+            }
+        }
+    }
+    if (count > 0) {
+        result.reprojection_error = std::sqrt(ssr / count);
+    }
+
+    const int num_params = static_cast<int>(4*num_cams + ((num_cams?num_cams-1:0)+num_views)*6);
+    const int dof = std::max(1, static_cast<int>(count) - num_params);
+    const double sigma2 = ssr / dof;
+
+    // Covariances
+    result.intrinsic_covariances.assign(num_cams, Eigen::Matrix4d::Zero());
+    result.camera_covariances.assign(num_cams, Eigen::Matrix<double,6,6>::Zero());
+    result.target_covariances.assign(num_views, Eigen::Matrix<double,6,6>::Zero());
+
+    ceres::Covariance::Options copt;
+    ceres::Covariance cov(copt);
+    std::vector<std::pair<const double*, const double*>> blocks;
+    for (size_t i = 0; i < num_cams; ++i) {
+        blocks.emplace_back(intr[i].data(), intr[i].data());
+        if (!problem.IsParameterBlockConstant(cam_poses[i].data())) {
+            blocks.emplace_back(cam_poses[i].data(), cam_poses[i].data());
+        }
+    }
+    for (size_t v = 0; v < num_views; ++v) {
+        blocks.emplace_back(targ_poses[v].data(), targ_poses[v].data());
+    }
+    if (cov.Compute(blocks, &problem)) {
+        for (size_t i = 0; i < num_cams; ++i) {
+            double Cov4x4[16];
+            cov.GetCovarianceBlock(intr[i].data(), intr[i].data(), Cov4x4);
+            Eigen::Map<Eigen::Matrix4d> C4(Cov4x4);
+            result.intrinsic_covariances[i] = sigma2 * C4;
+            if (!problem.IsParameterBlockConstant(cam_poses[i].data())) {
+                double Cov6x6[36];
+                cov.GetCovarianceBlock(cam_poses[i].data(), cam_poses[i].data(), Cov6x6);
+                Eigen::Map<Eigen::Matrix<double,6,6>> C6(Cov6x6);
+                result.camera_covariances[i] = sigma2 * C6;
+            }
+        }
+        for (size_t v = 0; v < num_views; ++v) {
+            double Cov6x6[36];
+            cov.GetCovarianceBlock(targ_poses[v].data(), targ_poses[v].data(), Cov6x6);
+            Eigen::Map<Eigen::Matrix<double,6,6>> C6(Cov6x6);
+            result.target_covariances[v] = sigma2 * C6;
+        }
+    }
 
     return result;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -64,3 +64,14 @@ target_link_libraries(extrinsics_test
 )
 gtest_discover_tests(extrinsics_test)
 
+# Test for joint intrinsics/extrinsics optimization
+add_executable(joint_test joint_test.cpp)
+target_link_libraries(joint_test
+    PRIVATE calibration
+    PRIVATE GTest::gtest_main
+    PRIVATE GTest::gmock_main
+    PRIVATE Eigen3::Eigen
+    PRIVATE Ceres::ceres
+)
+gtest_discover_tests(joint_test)
+

--- a/test/joint_test.cpp
+++ b/test/joint_test.cpp
@@ -1,0 +1,65 @@
+#include <gtest/gtest.h>
+
+#include <Eigen/Geometry>
+
+#include "calibration/extrinsics.h"
+
+using namespace vitavision;
+
+TEST(JointCalibration, RecoverAllParameters) {
+    const int kCams = 2;
+    CameraMatrix K{100.0, 100.0, 0.0, 0.0};
+    Eigen::VectorXd dist(2);
+    dist << 0.0, 0.0;
+
+    std::vector<Camera> cameras_gt = {Camera{K, dist}, Camera{K, dist}};
+
+    Eigen::Affine3d cam0 = Eigen::Affine3d::Identity();
+    Eigen::Affine3d cam1 = Eigen::Translation3d(1.0, 0.0, 0.0) * Eigen::Affine3d::Identity();
+    std::vector<Eigen::Affine3d> cam_gt = {cam0, cam1};
+
+    std::vector<Eigen::Affine3d> target_gt = {
+        Eigen::Translation3d(0.0, 0.0, 5.0) * Eigen::Affine3d::Identity(),
+        Eigen::Translation3d(0.5, -0.2, 4.0) * Eigen::AngleAxisd(0.3, Eigen::Vector3d::UnitY()),
+    };
+
+    std::vector<Eigen::Vector2d> points = {
+        {0.0, 0.0}, {1.0, 0.0}, {1.0, 1.0}, {0.0, 1.0}
+    };
+
+    std::vector<ExtrinsicPlanarView> views;
+    for (size_t v = 0; v < target_gt.size(); ++v) {
+        ExtrinsicPlanarView view;
+        view.observations.resize(kCams);
+        for (int c = 0; c < kCams; ++c) {
+            Eigen::Affine3d T = cam_gt[c] * target_gt[v];
+            for (const auto& xy : points) {
+                Eigen::Vector3d P = T * Eigen::Vector3d(xy.x(), xy.y(), 0.0);
+                Eigen::Vector2d norm(P.x()/P.z(), P.y()/P.z());
+                Eigen::Vector2d pix = cameras_gt[c].intrinsics.denormalize(norm);
+                view.observations[c].push_back({xy, pix});
+            }
+        }
+        views.push_back(std::move(view));
+    }
+
+    // Perturbed intrinsics for initialization
+    std::vector<Camera> cam_init = {
+        Camera{CameraMatrix{90.0, 95.0, 1.0, -1.0}, dist},
+        Camera{CameraMatrix{105.0, 98.0, -0.5, 0.5}, dist}
+    };
+
+    auto guess = make_initial_extrinsic_guess(views, cam_init);
+
+    auto res = optimize_joint_intrinsics_extrinsics(views, cam_init, guess.camera_poses, guess.target_poses);
+
+    EXPECT_LT(res.reprojection_error, 1e-6);
+    ASSERT_EQ(res.intrinsics.size(), static_cast<size_t>(kCams));
+    EXPECT_NEAR(res.intrinsics[0].fx, 100.0, 1e-3);
+    EXPECT_NEAR(res.intrinsics[0].fy, 100.0, 1e-3);
+    EXPECT_TRUE(res.camera_poses[1].translation().isApprox(cam_gt[1].translation(), 1e-3));
+    EXPECT_TRUE(res.target_poses[0].translation().isApprox(target_gt[0].translation(), 1e-3));
+    ASSERT_EQ(res.intrinsic_covariances.size(), static_cast<size_t>(kCams));
+    EXPECT_GT(res.intrinsic_covariances[0].trace(), 0.0);
+}
+


### PR DESCRIPTION
## Summary
- implement initial extrinsic and target pose guess from planar observations
- add joint optimization of intrinsics, extrinsics and target poses with covariance
- add test for joint calibration

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "Ceres")*
- `apt-get update` *(fails: repository ... 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c734faec83329a622860ae867684