### PR TITLE
Add reference camera hand-eye calibration API stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A C++ library for camera calibration and vision-related geometric transformation
 - Stereo camera calibration
 - Support for various camera models
 - JSON configuration import/export
+- Hand-eye calibration with reference camera support
 
 ## Dependencies
 
@@ -90,7 +91,24 @@ EOF
 
 ## Usage
 
-TODO
+### Hand-Eye Calibration
+
+The library models hand-eye calibration around a *reference camera*.  The
+reference camera uses the optimized hand–eye pose directly, while additional
+cameras are expressed via extrinsic transforms relative to this reference.  A
+simple call looks like:
+
+```cpp
+#include "calibration/handeye.h"
+
+using namespace vitavision;
+
+HandEyeOptions opts;
+opts.optimize_extrinsics = true;            // also refine per-camera extrinsics
+std::vector<Eigen::Affine3d> initial_ext;    // size = num_cams - 1
+HandEyeResult res = calibrate_hand_eye(initial_ext, opts);
+// res.extrinsics[0] is identity for the reference camera
+```
 
 ## Documentation
 

--- a/examples/handeye_example.cpp
+++ b/examples/handeye_example.cpp
@@ -1,0 +1,16 @@
+#include <iostream>
+#include <vector>
+
+#include "calibration/handeye.h"
+
+using namespace vitavision;
+
+int main() {
+    HandEyeOptions opts;
+    opts.optimize_extrinsics = true;
+    std::vector<Eigen::Affine3d> initial_ext; // empty for single camera
+    HandEyeResult res = calibrate_hand_eye(initial_ext, opts);
+    std::cout << res.summary << "\n";
+    return 0;
+}
+

--- a/include/calibration/handeye.h
+++ b/include/calibration/handeye.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <vector>
+#include <optional>
+
+#include <Eigen/Geometry>
+
+namespace vitavision {
+
+struct HandEyeOptions {
+    bool optimize_extrinsics = false;
+};
+
+struct HandEyeResult {
+    Eigen::Affine3d hand_eye = Eigen::Affine3d::Identity();
+    std::vector<Eigen::Affine3d> extrinsics; // reference->camera transforms
+    double reprojection_error = 0.0;
+    std::string summary;
+};
+
+// Simple placeholder API for hand-eye calibration.
+// The size of initial_extrinsics must be num_cams-1; the first camera is the reference.
+HandEyeResult calibrate_hand_eye(
+    const std::vector<Eigen::Affine3d>& initial_extrinsics,
+    const HandEyeOptions& options = HandEyeOptions());
+
+} // namespace vitavision
+

--- a/src/handeye.cpp
+++ b/src/handeye.cpp
@@ -1,0 +1,32 @@
+#include "calibration/handeye.h"
+
+namespace vitavision {
+
+// Placeholder residual structure demonstrating optional extrinsic handling.
+struct HandEyeReprojResidual {
+    HandEyeReprojResidual() = default;
+    template <typename T>
+    bool operator()(const T* he_ref6, const T* ext6, T* residuals) const {
+        static_cast<void>(he_ref6);
+        static_cast<void>(ext6);
+        static_cast<void>(residuals);
+        return true;
+    }
+};
+
+HandEyeResult calibrate_hand_eye(const std::vector<Eigen::Affine3d>& initial_extrinsics,
+                                 const HandEyeOptions& options) {
+    HandEyeResult result;
+    // First camera is the reference camera; identity transform.
+    result.extrinsics.emplace_back(Eigen::Affine3d::Identity());
+    result.extrinsics.insert(result.extrinsics.end(),
+                             initial_extrinsics.begin(),
+                             initial_extrinsics.end());
+    result.summary = options.optimize_extrinsics ?
+                     "Extrinsics optimization enabled (stub)." :
+                     "Extrinsics optimization disabled (stub).";
+    return result;
+}
+
+} // namespace vitavision
+


### PR DESCRIPTION
## Summary
- document reference camera concept and extrinsic optimization in README
- add hand-eye calibration API with extrinsic placeholders
- include simple example demonstrating new options

## Testing
- `cmake .. -G Ninja` *(fails: Could not find CeresConfig.cmake)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a96f01d66c8332a71d0096e3d350fd