### PR TITLE
Run unit tests in CI and add component docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,27 +96,14 @@ jobs:
           # Build with MSVC
           cmake --build "$env:BUILD_DIR" --config ${{ matrix.build_type }} -j 2
 
-      # ---------- Smoke tests ----------
-      - name: Run smoke test (Unix)
+      # ---------- Unit tests ----------
+      - name: Run unit tests (Unix)
         if: runner.os != 'Windows'
-        shell: bash
         run: |
-          "$BUILD_DIR/examples/homography" << 'EOF'
-          4
-          0   0    10 20
-          100 0    110 18
-          100 50   120 70
-          0   50   8  72
-          EOF
+          ctest --test-dir "$BUILD_DIR" --output-on-failure
 
-      - name: Run smoke test (Windows)
+      - name: Run unit tests (Windows)
         if: runner.os == 'Windows'
-        shell: bash
+        shell: pwsh
         run: |
-          "$BUILD_DIR/examples/homography.exe" << 'EOF'
-          4
-          0   0    10 20
-          100 0    110 18
-          100 50   120 70
-          0   50   8  72
-          EOF
+          ctest --test-dir "$env:BUILD_DIR" -C ${{ matrix.build_type }} --output-on-failure

--- a/doc/calib.md
+++ b/doc/calib.md
@@ -1,0 +1,29 @@
+# Camera Calibration
+
+The `calib` component performs full single camera calibration from multiple
+planar views. It exposes the **`calibrate_camera_planar`** function which takes a
+collection of `PlanarView` observations and estimates camera intrinsics,
+distortion coefficients and the pose of each view.
+
+## Algorithms
+
+1. **Homography and Pose Estimation** – Each planar view is converted to a
+   homography and decomposed to obtain an initial pose estimate.
+2. **Non-linear Optimization** – Intrinsics, distortion and poses are refined
+   jointly using bundle adjustment to minimise reprojection error.
+3. **Covariance Analysis** – After optimisation the covariance matrix of all
+   estimated parameters is computed to provide uncertainty information.
+
+## API
+
+```
+CameraCalibrationResult calibrate_camera_planar(
+    const std::vector<PlanarView>& views,
+    int num_radial,
+    const CameraMatrix& initial_guess,
+    bool verbose = false,
+    std::optional<CalibrationBounds> bounds = std::nullopt);
+```
+
+The returned `CameraCalibrationResult` contains the optimised camera matrix,
+distortion coefficients, per-view poses, covariance and error statistics.

--- a/doc/camera.md
+++ b/doc/camera.md
@@ -1,0 +1,29 @@
+# Camera Model
+
+The `camera` component combines a `CameraMatrix` with distortion coefficients to
+form a simple pinhole camera model. It provides utilities for projecting points
+using the intrinsic and distortion parameters.
+
+## Algorithms
+
+* **Distortion Application** – Normalized coordinates are warped using
+  `apply_distortion` to account for radial and tangential distortion.
+* **Denormalisation** – Distorted normalized coordinates are converted to pixel
+  coordinates through the intrinsic matrix.
+
+## API
+
+```
+struct Camera {
+    CameraMatrix intrinsics;
+    Eigen::VectorXd distortion;
+
+    template <typename T>
+    Eigen::Matrix<T,2,1> project_normalized(
+        const Eigen::Matrix<T,2,1>& xyn) const;
+};
+```
+
+`project_normalized` projects a point in normalized image coordinates to pixel
+coordinates by applying distortion and then denormalising using the camera
+matrix.

--- a/doc/distortion.md
+++ b/doc/distortion.md
@@ -1,0 +1,30 @@
+# Lens Distortion
+
+The `distortion` component provides functions for applying and estimating lens
+ distortion parameters.
+
+## Algorithms
+
+* **Distortion Model** – Supports an arbitrary number of radial coefficients plus
+tangential terms `p1` and `p2`. Distortion is applied to normalized coordinates
+with `apply_distortion`.
+* **Linear Least Squares Fit** – `fit_distortion_full` constructs a design
+matrix from observations and solves for distortion coefficients using SVD.
+* **Residual Analysis** – The solver returns residuals for diagnostic purposes.
+
+## API
+
+```
+template<typename T>
+Eigen::Matrix<T,2,1> apply_distortion(
+    const Eigen::Matrix<T,2,1>& norm_xy,
+    const Eigen::VectorXd& coeffs);
+
+std::optional<DistortionWithResiduals<T>> fit_distortion_full(
+    const std::vector<Observation<T>>& obs,
+    T fx, T fy, T cx, T cy,
+    int num_radial = 2);
+```
+
+These utilities model and estimate distortion to support downstream calibration
+steps.

--- a/doc/extrinsics.md
+++ b/doc/extrinsics.md
@@ -1,0 +1,37 @@
+# Extrinsic Calibration
+
+The `extrinsics` component estimates camera and target poses using planar
+observations from multiple cameras.
+
+## Algorithms
+
+1. **Initial Guess** – `make_initial_extrinsic_guess` triangulates planar poses
+   to seed camera and target transforms.
+2. **Joint Optimisation** – `optimize_joint_intrinsics_extrinsics` refines
+   intrinsics, distortion and all poses simultaneously to minimise pixel error.
+3. **Pose-Only Refinement** – `optimize_extrinsic_poses` adjusts camera and
+   target poses while keeping intrinsics fixed.
+4. **Covariance Computation** – Covariances for each pose and intrinsics are
+   returned for uncertainty analysis.
+
+## API
+
+```
+InitialExtrinsicGuess make_initial_extrinsic_guess(
+    const std::vector<ExtrinsicPlanarView>& views,
+    const std::vector<Camera>& cameras);
+
+JointOptimizationResult optimize_joint_intrinsics_extrinsics(
+    const std::vector<ExtrinsicPlanarView>& views,
+    const std::vector<Camera>& initial_cameras,
+    const std::vector<Eigen::Affine3d>& initial_camera_poses,
+    const std::vector<Eigen::Affine3d>& initial_target_poses,
+    bool verbose = false);
+
+ExtrinsicOptimizationResult optimize_extrinsic_poses(
+    const std::vector<ExtrinsicPlanarView>& views,
+    const std::vector<Camera>& cameras,
+    const std::vector<Eigen::Affine3d>& initial_camera_poses,
+    const std::vector<Eigen::Affine3d>& initial_target_poses,
+    bool verbose = false);
+```

--- a/doc/handeye.md
+++ b/doc/handeye.md
@@ -1,0 +1,30 @@
+# Hand-Eye Calibration
+
+The `handeye` component estimates the rigid transform between a robot gripper
+and a camera using planar target observations.
+
+## Algorithms
+
+1. **Tsai–Lenz Initialisation** – `estimate_hand_eye_initial` provides a closed
+   form solution from corresponding gripper and target poses.
+2. **Bundle Adjustment** – `calibrate_hand_eye` refines intrinsics, the
+   gripper-to-camera transform, optional target pose and extrinsics through a
+   non-linear optimisation.
+3. **Covariance Estimation** – The final solver computes covariance matrices for
+   pose parameters enabling accuracy assessment.
+
+## API
+
+```
+Eigen::Affine3d estimate_hand_eye_initial(
+    const std::vector<Eigen::Affine3d>& base_T_gripper,
+    const std::vector<Eigen::Affine3d>& target_T_camera);
+
+HandEyeResult calibrate_hand_eye(
+    const std::vector<HandEyeObservation>& observations,
+    const std::vector<CameraMatrix>& initial_intrinsics,
+    const Eigen::Affine3d& initial_hand_eye,
+    const std::vector<Eigen::Affine3d>& initial_extrinsics = {},
+    const Eigen::Affine3d& initial_base_target = Eigen::Affine3d::Identity(),
+    const HandEyeOptions& opts = {});
+```

--- a/doc/homography.md
+++ b/doc/homography.md
@@ -1,0 +1,23 @@
+# Homography Estimation
+
+The `homography` component estimates planar homographies and refines them for
+pose recovery and mapping tasks.
+
+## Algorithms
+
+* **Direct Linear Transform** – `estimate_homography_dlt` solves for the
+  homography matrix using the classic DLT algorithm with point correspondences.
+* **Non-linear Refinement** – `fit_homography` performs least-squares
+  optimisation to improve accuracy and robustness to noise.
+
+## API
+
+```
+Eigen::Matrix3d estimate_homography_dlt(
+    const std::vector<Eigen::Vector2d>& src,
+    const std::vector<Eigen::Vector2d>& dst);
+
+Eigen::Matrix3d fit_homography(
+    const std::vector<Eigen::Vector2d>& src,
+    const std::vector<Eigen::Vector2d>& dst);
+```

--- a/doc/intrinsics.md
+++ b/doc/intrinsics.md
@@ -1,0 +1,36 @@
+# Intrinsic Calibration
+
+The `intrinsics` component focuses on estimating camera matrix parameters and
+lens distortion from point observations.
+
+## Algorithms
+
+1. **Linear Estimation** – `estimate_intrinsics_linear` solves a least-squares
+   system for the camera matrix ignoring distortion, optionally with parameter
+   bounds.
+2. **Iterative Refinement** – `estimate_intrinsics_linear_iterative` alternates
+   between solving for distortion (`fit_distortion`) and recomputing intrinsics
+   for a robust initialisation.
+3. **Non-linear Optimisation** – `optimize_intrinsics` refines intrinsics and
+   distortion simultaneously while computing covariance and reprojection error
+   statistics.
+
+## API
+
+```
+std::optional<CameraMatrix> estimate_intrinsics_linear(
+    const std::vector<Observation<double>>& obs,
+    std::optional<CalibrationBounds> bounds = std::nullopt);
+
+std::optional<LinearInitResult> estimate_intrinsics_linear_iterative(
+    const std::vector<Observation<double>>& obs,
+    int num_radial,
+    int max_iterations = 5);
+
+IntrinsicOptimizationResult optimize_intrinsics(
+    const std::vector<Observation<double>>& obs,
+    int num_radial,
+    const CameraMatrix& initial_guess,
+    bool verb = false,
+    std::optional<CalibrationBounds> bounds = std::nullopt);
+```

--- a/doc/planarpose.md
+++ b/doc/planarpose.md
@@ -1,0 +1,32 @@
+# Planar Pose Estimation
+
+The `planarpose` component estimates the pose of a planar target relative to the
+camera from pixel observations.
+
+## Algorithms
+
+* **Homography Decomposition** – `pose_from_homography_normalized` converts a
+  homography in normalized coordinates into a 3D pose.
+* **Direct DLT Pose** – `estimate_planar_pose_dlt` forms a homography from
+  object and image points using the camera matrix and decomposes it to a pose.
+* **Non-linear Refinement** – `optimize_planar_pose` jointly estimates target
+  pose and lens distortion by minimising reprojection error and returns
+  covariance information.
+
+## API
+
+```
+Eigen::Affine3d pose_from_homography_normalized(const Eigen::Matrix3d& H);
+
+Eigen::Affine3d estimate_planar_pose_dlt(
+    const std::vector<Eigen::Vector2d>& obj_xy,
+    const std::vector<Eigen::Vector2d>& img_uv,
+    const CameraMatrix& intrinsics);
+
+PlanarPoseFitResult optimize_planar_pose(
+    const std::vector<Eigen::Vector2d>& obj_xy,
+    const std::vector<Eigen::Vector2d>& img_uv,
+    const CameraMatrix& intrinsics,
+    int num_radial = 2,
+    bool verbose = false);
+```


### PR DESCRIPTION
## Summary
- run full `ctest` suite in CI instead of smoke tests
- add new `doc` directory with per-component calibration documentation

## Testing
- `cmake -S . -B build && cmake --build build -j 2 && ctest --test-dir build --output-on-failure` *(fails: Could not find Ceres package)*

------
https://chatgpt.com/codex/tasks/task_e_68a99a0626508332a4ead3cf40db5d9d