### PR TITLE
Handle distortion in line-scan calibration and extend tests

### DIFF
--- a/include/calibration/linescan.h
+++ b/include/calibration/linescan.h
@@ -42,6 +42,7 @@ struct LineScanCalibrationResult final {
  */
 LineScanCalibrationResult calibrate_laser_plane(
     const std::vector<LineScanObservation>& views,
-    const CameraMatrix& intrinsics);
+    const CameraMatrix& intrinsics,
+    const Eigen::VectorXd& distortion);
 
 } // namespace vitavision

--- a/test/linescan_test.cpp
+++ b/test/linescan_test.cpp
@@ -1,35 +1,67 @@
 #include <gtest/gtest.h>
 #include <Eigen/Core>
+#include <Eigen/Geometry>
 
 #include "calibration/linescan.h"
 
 using namespace vitavision;
 
-TEST(LineScanCalibration, PlaneFit) {
+TEST(LineScanCalibration, PlaneFitFailsSingleView) {
     CameraMatrix K{1.0, 1.0, 0.0, 0.0};
+    Eigen::VectorXd dist;
 
     LineScanObservation view;
-    // four target correspondences (square)
     view.target_xy = {
         {-0.5, -0.5},
         { 0.5, -0.5},
         { 0.5,  0.5},
         {-0.5,  0.5}
     };
-    view.target_uv = view.target_xy; // with identity intrinsics this matches
+    view.target_uv = view.target_xy;
 
     // Laser plane y = 0.5 -> normal (0,1,0), d = -0.5
     for (double x = -0.4; x <= 0.4; x += 0.2) {
         view.laser_uv.emplace_back(x, 0.5);
     }
 
-    auto res = calibrate_laser_plane({view}, K);
-    for (const auto& lpix : view.laser_uv) {
-        Eigen::Vector3d hp = res.homography * Eigen::Vector3d(lpix.x(), lpix.y(), 1.0);
-        Eigen::Vector2d xy = hp.hnormalized();
-        EXPECT_NEAR(xy.x(), lpix.x(), 1e-6);
-        EXPECT_NEAR(xy.y(), -1.0, 1e-6);
+    auto res = calibrate_laser_plane({view}, K, dist);
+    Eigen::Vector4d true_plane(0.0, 1.0, 0.0, -0.5);
+    EXPECT_FALSE(res.plane.isApprox(true_plane, 1e-6));
+}
+
+static LineScanObservation create_view(const Eigen::Matrix3d& R, const Eigen::Vector3d& t) {
+    LineScanObservation v;
+    v.target_xy = {
+        {-0.5, -0.5},
+        { 0.5, -0.5},
+        { 0.5,  0.5},
+        {-0.5,  0.5}
+    };
+    for (const auto& pt : v.target_xy) {
+        Eigen::Vector3d Pc = R * Eigen::Vector3d(pt.x(), pt.y(), 0.0) + t;
+        v.target_uv.emplace_back(Pc.x() / Pc.z(), Pc.y() / Pc.z());
     }
+    for (double x = -0.4; x <= 0.4; x += 0.2) {
+        double y = (0.5 - t.y() - R(1,0) * x) / R(1,1);
+        Eigen::Vector3d Pc = R * Eigen::Vector3d(x, y, 0.0) + t;
+        v.laser_uv.emplace_back(Pc.x() / Pc.z(), Pc.y() / Pc.z());
+    }
+    return v;
+}
+
+TEST(LineScanCalibration, PlaneFitMultipleViews) {
+    CameraMatrix K{1.0, 1.0, 0.0, 0.0};
+    Eigen::VectorXd dist;
+
+    Eigen::Matrix3d R1 = Eigen::Matrix3d::Identity();
+    Eigen::Vector3d t1(0.0, 0.0, 1.0);
+    Eigen::Matrix3d R2 = Eigen::AngleAxisd(0.2, Eigen::Vector3d::UnitX()).toRotationMatrix();
+    Eigen::Vector3d t2(0.0, 0.0, 1.0);
+
+    auto v1 = create_view(R1, t1);
+    auto v2 = create_view(R2, t2);
+
+    auto res = calibrate_laser_plane({v1, v2}, K, dist);
     EXPECT_NEAR(res.plane[0], 0.0, 1e-6);
     EXPECT_NEAR(res.plane[1], 1.0, 1e-6);
     EXPECT_NEAR(res.plane[2], 0.0, 1e-6);


### PR DESCRIPTION
## Summary
- account for lens distortion when normalizing points during line-scan plane calibration
- add failing single-view and passing multi-view unit tests for laser plane fitting

## Testing
- `cmake ..` *(fails: Could not find Ceres package)*

------
https://chatgpt.com/codex/tasks/task_e_68ae025ddb9c83329d00e7ffdc1ebb06