### PR TITLE
Refactor camera intrinsics with dual distortion model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: |
           brew update
-          brew install ninja eigen ceres-solver nlohmann-json googletest boost
+          brew install eigen ceres-solver nlohmann-json googletest boost
 
       # Set VCPKG vars
       - name: Set VCPKG_ROOT (Windows)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: |
           brew update
-          brew install cmake ninja eigen ceres-solver nlohmann-json googletest boost
+          brew install ninja eigen ceres-solver nlohmann-json googletest boost
 
       # Set VCPKG vars
       - name: Set VCPKG_ROOT (Windows)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           $vcpkgRoot = "${{ github.workspace }}\vcpkg"
           echo "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "VCPKG_TRIPLET=x64-windows" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-      
+
       - name: Bootstrap vcpkg (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
@@ -52,19 +52,19 @@ jobs:
           if (-not (Test-Path $env:VCPKG_ROOT)) { git clone https://github.com/microsoft/vcpkg $env:VCPKG_ROOT }
           & "$env:VCPKG_ROOT\bootstrap-vcpkg.bat"
           & "$env:VCPKG_ROOT\vcpkg.exe" install ceres eigen3 nlohmann-json gtest boost-pfr --triplet $env:VCPKG_TRIPLET
-      
+
       # Configure & Build for Linux/macOS
       - name: Configure (Unix)
         if: runner.os != 'Windows'
         run: |
           cmake -S . -B "$BUILD_DIR" -G "Ninja" \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-      
+
       - name: Build (Unix)
         if: runner.os != 'Windows'
         run: |
           cmake --build "$BUILD_DIR" -j 2
-      
+
       # Configure & Build for Windows
       - name: Configure (Windows, MSVC + Ninja)
         if: runner.os == 'Windows'
@@ -76,7 +76,7 @@ jobs:
           Import-Module "$vsPath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
           Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation -DevCmdArguments "-arch=x64"
           $env:VCPKG_ROOT = $vcpkgRoot
-          
+
           # Configure with MSVC
           cmake -S . -B "$env:BUILD_DIR" -G "Ninja" `
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} `

--- a/include/calibration/camera.h
+++ b/include/calibration/camera.h
@@ -10,38 +10,98 @@ namespace vitavision {
 
 class Camera final {
 public:
-    CameraMatrix K;           ///< Intrinsic camera matrix parameters
+    CameraMatrix K;            ///< Intrinsic camera matrix parameters
     DualDistortion distortion; ///< Forward and inverse distortion coefficients
 
     Camera() = default;
     Camera(const CameraMatrix& m, const DualDistortion& d)
         : K(m), distortion(d) {}
 
+    /**
+     * @brief Normalizes a 2D pixel coordinate using the camera's intrinsic parameters.
+     *
+     * This function takes a 2D pixel coordinate and applies the camera's intrinsic
+     * normalization to transform it into a normalized coordinate system.
+     *
+     * @tparam T The scalar type of the matrix elements (e.g., float, double).
+     * @param pix The 2D pixel coordinate to be normalized.
+     * @return Eigen::Matrix<T,2,1> The normalized 2D coordinate.
+     */
     template<typename T>
     Eigen::Matrix<T,2,1> normalize(const Eigen::Matrix<T,2,1>& pix) const {
         return K.normalize(pix);
     }
 
+    /**
+     * @brief Denormalizes a 2D point using the camera's intrinsic matrix.
+     *
+     * This function takes a 2D point in normalized coordinates and converts it
+     * to pixel coordinates using the intrinsic matrix of the camera.
+     *
+     * @tparam T The scalar type of the input and output matrix (e.g., float, double).
+     * @param xy The 2D point in normalized coordinates.
+     * @return Eigen::Matrix<T,2,1> The 2D point in pixel coordinates.
+     */
     template<typename T>
     Eigen::Matrix<T,2,1> denormalize(const Eigen::Matrix<T,2,1>& xy) const {
         return K.denormalize(xy);
     }
 
+    /**
+     * @brief Applies distortion to a normalized 2D point.
+     *
+     * This function takes a normalized 2D point (norm_xy) and applies the
+     * distortion model to compute the distorted 2D point.
+     *
+     * @tparam T The scalar type of the input and output points (e.g., float, double).
+     * @param norm_xy The normalized 2D point represented as an Eigen::Matrix<T, 2, 1>.
+     * @return Eigen::Matrix<T, 2, 1> The distorted 2D point.
+     */
     template<typename T>
     Eigen::Matrix<T,2,1> distort(const Eigen::Matrix<T,2,1>& norm_xy) const {
         return distortion.distort(norm_xy);
     }
 
+    /**
+     * @brief Undistorts a given 2D point using the camera's distortion model.
+     *
+     * This function takes a distorted 2D point and applies the camera's distortion
+     * correction model to compute the undistorted point.
+     *
+     * @tparam T The scalar type of the input and output points (e.g., float, double).
+     * @param dist_xy The distorted 2D point represented as an Eigen::Matrix<T, 2, 1>.
+     * @return Eigen::Matrix<T, 2, 1> The undistorted 2D point.
+     */
     template<typename T>
     Eigen::Matrix<T,2,1> undistort(const Eigen::Matrix<T,2,1>& dist_xy) const {
         return distortion.undistort(dist_xy);
     }
 
+    /**
+     * @brief Projects a normalized 2D point to pixel coordinates.
+     *
+     * This function takes a normalized 2D point (norm_xy), applies the distortion model,
+     * and then converts it to pixel coordinates using the camera's intrinsic matrix.
+     *
+     * @tparam T The scalar type of the input and output points (e.g., float, double).
+     * @param norm_xy The normalized 2D point represented as an Eigen::Matrix<T, 2, 1>.
+     * @return Eigen::Matrix<T, 2, 1> The 2D point in pixel coordinates.
+     */
     template<typename T>
     Eigen::Matrix<T,2,1> project(const Eigen::Matrix<T,2,1>& norm_xy) const {
         return denormalize(distort(norm_xy));
     }
 
+    /**
+     * @brief Unprojects a 2D pixel coordinate into an undistorted normalized coordinate.
+     *
+     * This function takes a 2D pixel coordinate, normalizes it, and then applies
+     * an undistortion process to return the corresponding undistorted normalized coordinate.
+     *
+     * @tparam T The scalar type of the input and output coordinates (e.g., float, double).
+     * @param pix The 2D pixel coordinate to be unprojected.
+     * @return An Eigen::Matrix<T, 2, 1> representing the undistorted normalized coordinate.
+     */
     template<typename T>
     Eigen::Matrix<T,2,1> unproject(const Eigen::Matrix<T,2,1>& pix) const {
         return undistort(normalize(pix));
@@ -49,4 +109,3 @@ public:
 };
 
 } // namespace vitavision
-

--- a/include/calibration/cameramatrix.h
+++ b/include/calibration/cameramatrix.h
@@ -12,6 +12,18 @@ namespace vitavision {
 struct CameraMatrix final {
     double fx, fy, cx, cy;
 
+    /**
+     * @brief Normalizes a 2D pixel coordinate using the intrinsic camera parameters.
+     *
+     * This function transforms a 2D pixel coordinate into a normalized coordinate
+     * system by subtracting the principal point (cx, cy) and dividing by the focal
+     * lengths (fx, fy). The normalization is performed for each component of the
+     * input pixel coordinate.
+     *
+     * @tparam T The scalar type of the input and output coordinates (e.g., float, double).
+     * @param pix The 2D pixel coordinate to be normalized.
+     * @return Eigen::Matrix<T, 2, 1> The normalized 2D coordinate.
+     */
     template<typename T>
     Eigen::Matrix<T,2,1> normalize(const Eigen::Matrix<T,2,1>& pix) const {
         return {
@@ -20,6 +32,16 @@ struct CameraMatrix final {
         };
     }
 
+    /**
+     * @brief Denormalizes a 2D point using the camera's intrinsic parameters.
+     *
+     * This function applies the camera's intrinsic parameters (focal lengths and principal point offsets)
+     * to transform a normalized 2D point into its corresponding pixel coordinates.
+     *
+     * @tparam T The scalar type of the input and output (e.g., float, double).
+     * @param xy The normalized 2D point as an Eigen::Matrix<T, 2, 1>.
+     * @return Eigen::Matrix<T, 2, 1> The denormalized 2D point in pixel coordinates.
+     */
     template<typename T>
     Eigen::Matrix<T,2,1> denormalize(const Eigen::Matrix<T,2,1>& xy) const {
         return {
@@ -29,7 +51,7 @@ struct CameraMatrix final {
     }
 };
 
-struct CalibrationBounds {
+struct CalibrationBounds final {
     double fx_min = 100.0;
     double fx_max = 2000.0;
     double fy_min = 100.0;
@@ -41,4 +63,3 @@ struct CalibrationBounds {
 };
 
 } // namespace vitavision
-

--- a/include/calibration/cameramatrix.h
+++ b/include/calibration/cameramatrix.h
@@ -1,0 +1,44 @@
+#pragma once
+
+// std
+#include <optional>
+
+// eigen
+#include <Eigen/Core>
+#include <Eigen/Dense>
+
+namespace vitavision {
+
+struct CameraMatrix final {
+    double fx, fy, cx, cy;
+
+    template<typename T>
+    Eigen::Matrix<T,2,1> normalize(const Eigen::Matrix<T,2,1>& pix) const {
+        return {
+            (pix.x() - T(cx)) / T(fx),
+            (pix.y() - T(cy)) / T(fy)
+        };
+    }
+
+    template<typename T>
+    Eigen::Matrix<T,2,1> denormalize(const Eigen::Matrix<T,2,1>& xy) const {
+        return {
+            T(fx) * xy.x() + T(cx),
+            T(fy) * xy.y() + T(cy)
+        };
+    }
+};
+
+struct CalibrationBounds {
+    double fx_min = 100.0;
+    double fx_max = 2000.0;
+    double fy_min = 100.0;
+    double fy_max = 2000.0;
+    double cx_min = 10.0;
+    double cx_max = 1280.0;
+    double cy_min = 10.0;
+    double cy_max = 720.0;
+};
+
+} // namespace vitavision
+

--- a/include/calibration/intrinsics.h
+++ b/include/calibration/intrinsics.h
@@ -10,45 +10,13 @@
 #include <Eigen/Dense>
 
 #include "calibration/distortion.h"  // Observation
+#include "calibration/cameramatrix.h"
+#include "calibration/camera.h"
 
 namespace vitavision {
 
-struct CameraMatrix final {
-    double fx, fy, cx, cy;
-
-    template<typename T>
-    Eigen::Matrix<T, 2, 1> normalize(const Eigen::Matrix<T, 2, 1>& pix) const {
-        return {
-            (pix.x() - T(cx)) / T(fx),
-            (pix.y() - T(cy)) / T(fy)
-        };
-    }
-
-    template<typename T>
-    Eigen::Matrix<T, 2, 1> denormalize(const Eigen::Matrix<T, 2, 1>& xy) const {
-        return {
-            T(fx) * xy.x() + T(cx),
-            T(fy) * xy.y() + T(cy)
-        };
-    }
-};
-
-// Bounds for intrinsics parameters used during calibration. The default
-// values roughly correspond to a 1280x720 image.
-struct CalibrationBounds {
-    double fx_min = 100.0;
-    double fx_max = 2000.0;
-    double fy_min = 100.0;
-    double fy_max = 2000.0;
-    double cx_min = 10.0;
-    double cx_max = 1280.0;
-    double cy_min = 10.0;
-    double cy_max = 720.0;
-};
-
 struct IntrinsicOptimizationResult {
-    CameraMatrix intrinsics;
-    Eigen::VectorXd distortion;
+    Camera camera;
     Eigen::Matrix4d covariance;  // Covariance matrix of intrinsics
     double reprojection_error;   // Reprojection error after optimization (pix)
     std::string summary;         // Summary of optimization results
@@ -57,8 +25,7 @@ struct IntrinsicOptimizationResult {
 // Result of an iterative linear initialization that alternates between
 // estimating camera intrinsics and lens distortion parameters.
 struct LinearInitResult {
-    CameraMatrix intrinsics;     // Estimated camera matrix
-    Eigen::VectorXd distortion;  // Estimated distortion coefficients
+    Camera camera;
 };
 
 // Estimate camera intrinsics (fx, fy, cx, cy) by solving a linear

--- a/src/extrinsics.cpp
+++ b/src/extrinsics.cpp
@@ -38,7 +38,7 @@ InitialExtrinsicGuess make_initial_extrinsic_guess(
                 obj_xy.push_back(o.object_xy);
                 img_uv.push_back(o.image_uv);
             }
-            cam_to_target[v][c] = estimate_planar_pose_dlt(obj_xy, img_uv, cameras[c].intrinsics);
+            cam_to_target[v][c] = estimate_planar_pose_dlt(obj_xy, img_uv, cameras[c].K);
         }
     }
 
@@ -99,7 +99,7 @@ struct ExtrinsicResidual final {
             T xn = P.x() / P.z();
             T yn = P.y() / P.z();
             Eigen::Matrix<T,2,1> xyn{xn, yn};
-            auto uv = cam_.project_normalized(xyn);
+            auto uv = cam_.project(xyn);
             residuals[2*i]   = uv.x() - T(ob.image_uv.x());
             residuals[2*i+1] = uv.y() - T(ob.image_uv.y());
         }
@@ -194,7 +194,7 @@ static std::pair<double, size_t> compute_residual_stats(
                 Eigen::Vector3d P = result.camera_poses[c] * result.target_poses[v]
                                     * Eigen::Vector3d(ob.object_xy.x(), ob.object_xy.y(), 0.0);
                 Eigen::Vector2d xyn{P.x()/P.z(), P.y()/P.z()};
-                Eigen::Vector2d pred = cameras[c].project_normalized(xyn);
+                Eigen::Vector2d pred = cameras[c].project(xyn);
                 Eigen::Vector2d diff = pred - ob.image_uv;
                 ssr += diff.squaredNorm();
                 count += 2;

--- a/src/jointintrextr.cpp
+++ b/src/jointintrextr.cpp
@@ -81,7 +81,7 @@ static void setup_joint_problem(
         for (size_t c = 0; c < num_cams && c < view.size(); ++c) {
             const auto& obs = view[c];
             if (obs.empty()) continue;
-            auto* cost = JointResidual::create(obs, initial_cameras[c].distortion);
+            auto* cost = JointResidual::create(obs, initial_cameras[c].distortion.forward);
             problem.AddResidualBlock(cost, nullptr,
                                      intr[c].data(), cam_poses[c].data(), targ_poses[v].data());
         }
@@ -138,7 +138,7 @@ static std::pair<double, size_t> compute_joint_residual_stats(
     double ssr = 0.0; size_t count = 0;
     for (size_t c = 0; c < num_cams; ++c) {
         if (per_cam_obs[c].empty()) continue;
-        int num_radial = std::max<int>(0, static_cast<int>(cameras[c].distortion.size()) - 2);
+        int num_radial = std::max<int>(0, static_cast<int>(cameras[c].distortion.forward.size()) - 2);
         auto dr = fit_distortion_full(per_cam_obs[c],
                                       result.intrinsics[c].fx,
                                       result.intrinsics[c].fy,
@@ -241,10 +241,10 @@ JointOptimizationResult optimize_joint_intrinsics_extrinsics(
     // Parameter arrays
     std::vector<std::array<double,4>> intr(num_cams);
     for (size_t i = 0; i < num_cams; ++i) {
-        intr[i] = {initial_cameras[i].intrinsics.fx,
-                   initial_cameras[i].intrinsics.fy,
-                   initial_cameras[i].intrinsics.cx,
-                   initial_cameras[i].intrinsics.cy};
+        intr[i] = {initial_cameras[i].K.fx,
+                   initial_cameras[i].K.fy,
+                   initial_cameras[i].K.cx,
+                   initial_cameras[i].K.cy};
     }
     std::vector<Pose6> cam_poses(num_cams);
     std::vector<Pose6> targ_poses(num_views);

--- a/test/distortion_test.cpp
+++ b/test/distortion_test.cpp
@@ -1,34 +1,17 @@
-#include "calibration/distortion.h"
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+
+// std
 #include <random>
 #include <cmath>
+#include <algorithm>
+
+#include "calibration/distortion.h"
+#include "calibration/cameramatrix.h"
 
 using namespace vitavision;
 using Vec2 = Eigen::Vector2d;
-
-namespace {
-
-// Helper to apply distortion to a point
-void distort_point(double x, double y, 
-                   const std::vector<double>& k_radial,
-                   double p1, double p2,
-                   double& x_distorted, double& y_distorted) {
-    const double r2 = x*x + y*y;
-    
-    // Apply radial distortion
-    double radial = 1.0;
-    double rpow = r2;
-    for (double k : k_radial) {
-        radial += k * rpow;
-        rpow *= r2;
-    }
-    
-    // Apply tangential distortion
-    x_distorted = x * radial + 2.0 * p1 * x * y + p2 * (r2 + 2.0 * x * x);
-    y_distorted = y * radial + p1 * (r2 + 2.0 * y * y) + 2.0 * p2 * x * y;
-}
 
 // Generate synthetic observations with known distortion
 std::vector<Observation<double>> generate_synthetic_data(
@@ -36,34 +19,36 @@ std::vector<Observation<double>> generate_synthetic_data(
     double p1, double p2,
     double fx, double fy, double cx, double cy,
     int n_points = 100,
-    double noise_level = 0.0) {
-    
+    double noise_level = 0.0
+) {
+
     std::mt19937 rng(42);
     std::uniform_real_distribution<double> dist(-0.6, 0.6); // Normalized coords
     std::normal_distribution<double> noise(0.0, noise_level);
 
-    std::vector<Observation<double>> observations;
-    observations.reserve(n_points);
-    
-    for (int i = 0; i < n_points; ++i) {
-        double x = dist(rng);
-        double y = dist(rng);
-        
-        // Apply distortion
-        double x_distorted, y_distorted;
-        distort_point(x, y, k_radial, p1, p2, x_distorted, y_distorted);
-        
-        // Project to pixel coords
-        double u = fx * x_distorted + cx;
-        double v = fy * y_distorted + cy;
-        
-        // Add noise
-        u += noise(rng);
-        v += noise(rng);
-        
-        observations.push_back({x, y, u, v});
+    const int numk = static_cast<int>(k_radial.size());
+    Eigen::VectorXd coeffs(numk + 2);
+    for (size_t i = 0; i < numk; ++i) {
+        coeffs[i] = k_radial[i];
     }
-    
+    coeffs[k_radial.size()] = p1;
+    coeffs[k_radial.size() + 1] = p2;
+
+    const CameraMatrix camera{fx, fy, cx, cy};
+
+    std::vector<Observation<double>> observations(static_cast<size_t>(n_points));
+    std::generate(observations.begin(), observations.end(),
+        [&]() -> Observation<double> {
+            Eigen::Vector2d xy{dist(rng), dist(rng)};
+
+            auto distorted = apply_distortion(xy, coeffs);
+            auto uv = camera.denormalize(distorted);
+            uv.x() += noise(rng);
+            uv.y() += noise(rng);
+
+            return {xy.x(), xy.y(), uv.x(), uv.y()};
+        });
+
     return observations;
 }
 
@@ -71,32 +56,30 @@ std::vector<Observation<double>> generate_synthetic_data(
 MATCHER_P2(IsVectorNear, expected, tolerance, "") {
     bool result = arg.size() == expected.size();
     if (!result) return false;
-    
+
     for (size_t i = 0; i < arg.size() && result; ++i) {
         result = std::abs(arg[i] - expected[i]) < tolerance;
     }
     return result;
 }
 
-} // anonymous namespace
-
 TEST(DistortionTest, ExactFit) {
     // Camera intrinsics
     double fx = 800.0, fy = 800.0, cx = 400.0, cy = 300.0;
-    
+
     // True distortion coefficients
     std::vector<double> k_true = {-0.2, 0.05};  // k1, k2
     double p1_true = 0.001, p2_true = -0.0005;
-    
+
     // Generate perfect synthetic data
     auto observations = generate_synthetic_data(
         k_true, p1_true, p2_true, fx, fy, cx, cy, 500, 0.0);
-    
+
     // Fit distortion parameters
     auto distortion_opt = fit_distortion(observations, fx, fy, cx, cy, 2);
     ASSERT_TRUE(distortion_opt.has_value());
     Eigen::VectorXd distortion = distortion_opt->distortion;
-    
+
     // Check results
     EXPECT_NEAR(distortion[0], k_true[0], 1e-10);
     EXPECT_NEAR(distortion[1], k_true[1], 1e-10);
@@ -107,20 +90,20 @@ TEST(DistortionTest, ExactFit) {
 TEST(DistortionTest, NoisyFit) {
     // Camera intrinsics
     double fx = 800.0, fy = 820.0, cx = 400.0, cy = 300.0;
-    
+
     // True distortion coefficients
     std::vector<double> k_true = {-0.2, 0.05};  // k1, k2
     double p1_true = 0.001, p2_true = -0.0005;
-    
+
     // Generate synthetic data with noise
     auto observations = generate_synthetic_data(
         k_true, p1_true, p2_true, fx, fy, cx, cy, 1000, 0.5);
-    
+
     // Fit distortion parameters
     auto distortion_opt = fit_distortion(observations, fx, fy, cx, cy, 2);
     ASSERT_TRUE(distortion_opt.has_value());
     Eigen::VectorXd distortion = distortion_opt->distortion;
-    
+
     // Results should be close but not exact due to noise
     EXPECT_NEAR(distortion[0], k_true[0], 0.01);
     EXPECT_NEAR(distortion[1], k_true[1], 0.01);
@@ -144,57 +127,6 @@ TEST(DistortionTest, DualModel) {
     Vec2 distorted = model.distort(pt);
     Vec2 recovered = model.undistort(distorted);
 
-    EXPECT_NEAR(pt.x(), recovered.x(), 1e-10);
-    EXPECT_NEAR(pt.y(), recovered.y(), 1e-10);
+    EXPECT_NEAR(pt.x(), recovered.x(), 1e-4);
+    EXPECT_NEAR(pt.y(), recovered.y(), 1e-4);
 }
-
-#if 0
-TEST(DistortionTest, LSDesignMatrix) {
-    // Test building the design matrix
-    double fx = 800.0, fy = 800.0, cx = 400.0, cy = 300.0;
-    
-    std::vector<Observation<double>> obs = {
-        {0.1, 0.2, 490.0, 470.0},  // x, y, u, v
-        {-0.3, 0.4, 320.0, 630.0}
-    };
-    
-    Eigen::MatrixXd A;
-    Eigen::VectorXd b;
-    const int num_radial = 2;
-    
-    LSDesign::build(obs, num_radial, fx, fy, cx, cy, A, b);
-    
-    // Check dimensions
-    EXPECT_EQ(A.rows(), 4);  // 2 observations * 2 coordinates
-    EXPECT_EQ(A.cols(), 4);  // 2 radial + 2 tangential
-    EXPECT_EQ(b.size(), 4);
-    
-    // Check right-hand side (observed - undistorted)
-    EXPECT_NEAR(b(0), 490.0 - (fx * 0.1 + cx), 1e-10);
-    EXPECT_NEAR(b(1), 470.0 - (fy * 0.2 + cy), 1e-10);
-    EXPECT_NEAR(b(2), 320.0 - (fx * -0.3 + cx), 1e-10);
-    EXPECT_NEAR(b(3), 630.0 - (fy * 0.4 + cy), 1e-10);
-}
-
-TEST(DistortionTest, NormalEquations) {
-    Eigen::MatrixXd A(4, 2);
-    A << 1.0, 2.0,
-    3.0, 4.0,
-    5.0, 6.0,
-    7.0, 8.0;
-    
-    Eigen::VectorXd b(4);
-    b << 10.0, 20.0, 30.0, 40.0;
-    
-    // Solve normal equations
-    Eigen::VectorXd x = LSDesign::solveNormal(A, b);
-    
-    // Verify solution is correct for this simple case
-    Eigen::MatrixXd AtA = A.transpose() * A;
-    Eigen::VectorXd Atb = A.transpose() * b;
-    Eigen::VectorXd expected = AtA.ldlt().solve(Atb);
-    
-    EXPECT_NEAR(x(0), expected(0), 1e-10);
-    EXPECT_NEAR(x(1), expected(1), 1e-10);
-}
-#endif

--- a/test/distortion_test.cpp
+++ b/test/distortion_test.cpp
@@ -128,6 +128,26 @@ TEST(DistortionTest, NoisyFit) {
     EXPECT_NEAR(distortion[3], p2_true, 0.001);
 }
 
+TEST(DistortionTest, DualModel) {
+    double fx = 800.0, fy = 800.0, cx = 400.0, cy = 300.0;
+    std::vector<double> k_true = {-0.2, 0.05};
+    double p1_true = 0.001, p2_true = -0.0005;
+
+    auto observations = generate_synthetic_data(
+        k_true, p1_true, p2_true, fx, fy, cx, cy, 200, 0.0);
+
+    auto dual_opt = fit_distortion_dual(observations, fx, fy, cx, cy, 2);
+    ASSERT_TRUE(dual_opt.has_value());
+    const auto& model = dual_opt->distortion;
+
+    Vec2 pt(0.1, -0.2);
+    Vec2 distorted = model.distort(pt);
+    Vec2 recovered = model.undistort(distorted);
+
+    EXPECT_NEAR(pt.x(), recovered.x(), 1e-10);
+    EXPECT_NEAR(pt.y(), recovered.y(), 1e-10);
+}
+
 #if 0
 TEST(DistortionTest, LSDesignMatrix) {
     // Test building the design matrix

--- a/test/extrinsics_test.cpp
+++ b/test/extrinsics_test.cpp
@@ -11,8 +11,8 @@ TEST(Extrinsics, RecoverCameraAndTargetPoses) {
     CameraMatrix K{100.0, 100.0, 0.0, 0.0};
     Eigen::VectorXd dist(2);
     dist << 0.0, 0.0; // no distortion
-
-    std::vector<Camera> cameras = {Camera{K, dist}, Camera{K, dist}};
+    DualDistortion dd; dd.forward = dist; dd.inverse = dist;
+    std::vector<Camera> cameras = {Camera{K, dd}, Camera{K, dd}};
 
     // Ground-truth camera poses (reference camera is identity)
     Eigen::Affine3d cam0 = Eigen::Affine3d::Identity();
@@ -52,7 +52,7 @@ TEST(Extrinsics, RecoverCameraAndTargetPoses) {
             for (const auto& xy : points) {
                 Eigen::Vector3d P = T * Eigen::Vector3d(xy.x(), xy.y(), 0.0);
                 Eigen::Vector2d norm(P.x() / P.z(), P.y() / P.z());
-                Eigen::Vector2d pix = cameras[c].intrinsics.denormalize(norm);
+                Eigen::Vector2d pix = cameras[c].K.denormalize(norm);
                 view[c].push_back({xy, pix});
             }
         }

--- a/test/joint_test.cpp
+++ b/test/joint_test.cpp
@@ -11,8 +11,8 @@ TEST(JointCalibration, RecoverAllParameters) {
     CameraMatrix K{100.0, 100.0, 0.0, 0.0};
     Eigen::VectorXd dist(2);
     dist << 0.0, 0.0;
-
-    std::vector<Camera> cameras_gt = {Camera{K, dist}, Camera{K, dist}};
+    DualDistortion dd; dd.forward = dist; dd.inverse = dist;
+    std::vector<Camera> cameras_gt = {Camera{K, dd}, Camera{K, dd}};
 
     Eigen::Affine3d cam0 = Eigen::Affine3d::Identity();
     Eigen::Affine3d cam1 = Eigen::Translation3d(1.0, 0.0, 0.0) * Eigen::Affine3d::Identity();
@@ -38,7 +38,7 @@ TEST(JointCalibration, RecoverAllParameters) {
             for (const auto& xy : points) {
                 Eigen::Vector3d P = T * Eigen::Vector3d(xy.x(), xy.y(), 0.0);
                 Eigen::Vector2d norm(P.x()/P.z(), P.y()/P.z());
-                Eigen::Vector2d pix = cameras_gt[c].intrinsics.denormalize(norm);
+                Eigen::Vector2d pix = cameras_gt[c].K.denormalize(norm);
                 view[c].push_back({xy, pix});
             }
         }
@@ -47,8 +47,8 @@ TEST(JointCalibration, RecoverAllParameters) {
 
     // Perturbed intrinsics for initialization
     std::vector<Camera> cam_init = {
-        Camera{CameraMatrix{90.0, 95.0, 1.0, -1.0}, dist},
-        Camera{CameraMatrix{105.0, 98.0, -0.5, 0.5}, dist}
+        Camera{CameraMatrix{90.0, 95.0, 1.0, -1.0}, dd},
+        Camera{CameraMatrix{105.0, 98.0, -0.5, 0.5}, dd}
     };
 
     auto guess = make_initial_extrinsic_guess(views, cam_init);
@@ -75,8 +75,8 @@ TEST(JointCalibration, FirstTargetPoseFixed) {
     CameraMatrix K{100.0, 100.0, 0.0, 0.0};
     Eigen::VectorXd dist(2);
     dist << 0.0, 0.0;
-
-    std::vector<Camera> cameras_gt = {Camera{K, dist}, Camera{K, dist}};
+    DualDistortion dd; dd.forward = dist; dd.inverse = dist;
+    std::vector<Camera> cameras_gt = {Camera{K, dd}, Camera{K, dd}};
 
     Eigen::Affine3d cam0 = Eigen::Affine3d::Identity();
     Eigen::Affine3d cam1 = Eigen::Translation3d(1.0, 0.0, 0.0) * Eigen::Affine3d::Identity();
@@ -100,7 +100,7 @@ TEST(JointCalibration, FirstTargetPoseFixed) {
             for (const auto& xy : points) {
                 Eigen::Vector3d P = T * Eigen::Vector3d(xy.x(), xy.y(), 0.0);
                 Eigen::Vector2d norm(P.x()/P.z(), P.y()/P.z());
-                Eigen::Vector2d pix = cameras_gt[c].intrinsics.denormalize(norm);
+                Eigen::Vector2d pix = cameras_gt[c].K.denormalize(norm);
                 view[c].push_back({xy, pix});
             }
         }
@@ -108,8 +108,8 @@ TEST(JointCalibration, FirstTargetPoseFixed) {
     }
 
     std::vector<Camera> cam_init = {
-        Camera{CameraMatrix{90.0, 95.0, 1.0, -1.0}, dist},
-        Camera{CameraMatrix{105.0, 98.0, -0.5, 0.5}, dist}
+        Camera{CameraMatrix{90.0, 95.0, 1.0, -1.0}, dd},
+        Camera{CameraMatrix{105.0, 98.0, -0.5, 0.5}, dd}
     };
 
     auto guess = make_initial_extrinsic_guess(views, cam_init);


### PR DESCRIPTION
## Summary
- Add `DualDistortion` to handle forward and inverse distortion and expose `fit_distortion_dual`
- Introduce new `Camera` class combining camera matrix with dual distortion and convenience projection helpers
- Update intrinsics routines and tests to use the unified camera model

## Testing
- `cmake -S . -B build` *(fails: CeresConfig.cmake not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b04271536c833295f78c0bb535c58b