### PR TITLE
Implement dual distortion constructors and update linescan tests

### DIFF
--- a/include/calibration/camera.h
+++ b/include/calibration/camera.h
@@ -16,6 +16,8 @@ public:
     Camera() = default;
     Camera(const CameraMatrix& m, const DualDistortion& d)
         : K(m), distortion(d) {}
+    Camera(const CameraMatrix& m, const Eigen::VectorXd& d)
+        : K(m), distortion(d) {}
 
     /**
      * @brief Normalizes a 2D pixel coordinate using the camera's intrinsic parameters.

--- a/test/linescan_test.cpp
+++ b/test/linescan_test.cpp
@@ -51,6 +51,7 @@ static LineScanObservation create_view(const Eigen::Matrix3d& R, const Eigen::Ve
 TEST(LineScanCalibration, PlaneFitMultipleViews) {
     CameraMatrix K{1.0, 1.0, 0.0, 0.0};
     Eigen::VectorXd dist;
+    Camera camera(K, dist);
 
     Eigen::Matrix3d R1 = Eigen::Matrix3d::Identity();
     Eigen::Vector3d t1(0.0, 0.0, 1.0);
@@ -60,7 +61,7 @@ TEST(LineScanCalibration, PlaneFitMultipleViews) {
     auto v1 = create_view(R1, t1);
     auto v2 = create_view(R2, t2);
 
-    auto res = calibrate_laser_plane({v1, v2}, K, dist);
+    auto res = calibrate_laser_plane({v1, v2}, camera);
     EXPECT_NEAR(res.plane[0], 0.0, 1e-6);
     EXPECT_NEAR(res.plane[1], 1.0, 1e-6);
     EXPECT_NEAR(res.plane[2], 0.0, 1e-6);


### PR DESCRIPTION
## Summary
- Added `DualDistortion` constructor that estimates inverse coefficients by grid sampling
- Enabled constructing `Camera` from single distortion coefficient vector
- Updated linescan unit tests to use new constructors

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Ceres")*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fc9b27d083329cb79440c657d332