### PR TITLE
Add Scheimpflug camera model

### DIFF
--- a/include/calibration/camera.h
+++ b/include/calibration/camera.h
@@ -95,6 +95,23 @@ public:
     }
 
     /**
+     * @brief Projects a 3D point onto a 2D plane using camera intrinsic parameters.
+     *
+     * This function takes a 3D point in homogeneous coordinates, normalizes it to 2D,
+     * applies distortion to the normalized coordinates, and then denormalizes the
+     * distorted coordinates to obtain the final 2D projection.
+     *
+     * @tparam T The scalar type of the input and output (e.g., float, double).
+     * @param xyz A 3D point in homogeneous coordinates represented as an Eigen::Matrix<T,3,1>.
+     * @return A 2D point in the image plane represented as an Eigen::Matrix<T,2,1>.
+     */
+    template<typename T>
+    Eigen::Matrix<T,2,1> project(const Eigen::Matrix<T,3,1>& xyz) const {
+        Eigen::Matrix<T,2,1> norm_xy = xyz.hnormalized();
+        return denormalize(distort(norm_xy));
+    }
+
+    /**
      * @brief Unprojects a 2D pixel coordinate into an undistorted normalized coordinate.
      *
      * This function takes a 2D pixel coordinate, normalizes it, and then applies

--- a/include/calibration/scheimpflug.h
+++ b/include/calibration/scheimpflug.h
@@ -1,9 +1,11 @@
 #pragma once
 
+// std
+#include <cmath>
+
 // eigen
 #include <Eigen/Core>
 #include <Eigen/Geometry>
-#include <cmath>
 
 #include "calibration/camera.h"
 
@@ -65,9 +67,9 @@ struct ScheimpflugCamera final {
         T my = bs.dot(Xc) / sden;
 
         // Principal ray intersection with the plane
-        T s0 = ns.z();
-        T mx0 = as.z() / s0;
-        T my0 = bs.z() / s0;
+        const T s0 = ns.z();
+        const T mx0 = as.z() / s0;
+        const T my0 = bs.z() / s0;
 
         // Distortion in plane coordinates
         Eigen::Matrix<T,2,1> dxy(mx - mx0, my - my0);
@@ -83,4 +85,3 @@ struct ScheimpflugCamera final {
 };
 
 } // namespace vitavision
-

--- a/include/calibration/scheimpflug.h
+++ b/include/calibration/scheimpflug.h
@@ -1,0 +1,86 @@
+#pragma once
+
+// eigen
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+#include <cmath>
+
+#include "calibration/camera.h"
+
+namespace vitavision {
+
+/**
+ * @brief Camera model with a tilted sensor plane (Scheimpflug configuration).
+ *
+ * The camera follows the central projection model but the image sensor is
+ * tilted with respect to the optical axis.  The tilt is parameterised by two
+ * angles: tau_x is a rotation around the camera X axis and tau_y around the Y
+ * axis.  Distortion is applied in the metric coordinates on the tilted sensor
+ * plane.
+ */
+struct ScheimpflugCamera final {
+    Camera camera;   ///< Intrinsics and distortion parameters
+    double tau_x{0}; ///< Tilt around the X axis (radians)
+    double tau_y{0}; ///< Tilt around the Y axis (radians)
+
+    ScheimpflugCamera() = default;
+    ScheimpflugCamera(const Camera& cam, double tx, double ty)
+        : camera(cam), tau_x(tx), tau_y(ty) {}
+
+    /**
+     * @brief Project a 3D point in the camera frame to pixel coordinates.
+     *
+     * @tparam T Scalar type (double or ceres::Jet)
+     * @param Xc 3D point expressed in the camera frame
+     * @return Eigen::Matrix<T,2,1> Pixel coordinates
+     */
+    template <typename T>
+    Eigen::Matrix<T,2,1> project(const Eigen::Matrix<T,3,1>& Xc) const {
+        // Build rotation that aligns the tilted sensor basis
+        const T tx = T(tau_x);
+        const T ty = T(tau_y);
+        const T ctx = std::cos(tx);
+        const T stx = std::sin(tx);
+        const T cty = std::cos(ty);
+        const T sty = std::sin(ty);
+
+        Eigen::Matrix<T,3,3> Rx;
+        Rx << T(1), T(0), T(0),
+              T(0), ctx, -stx,
+              T(0), stx,  ctx;
+        Eigen::Matrix<T,3,3> Ry;
+        Ry << cty, T(0), sty,
+              T(0), T(1), T(0),
+              -sty, T(0), cty;
+        Eigen::Matrix<T,3,3> Rs = Ry * Rx;
+
+        // Basis vectors of the tilted sensor plane
+        Eigen::Matrix<T,3,1> as = Rs.col(0);
+        Eigen::Matrix<T,3,1> bs = Rs.col(1);
+        Eigen::Matrix<T,3,1> ns = Rs.col(2);
+
+        // Ray-plane intersection (d=1)
+        T sden = ns.dot(Xc);
+        T mx = as.dot(Xc) / sden;
+        T my = bs.dot(Xc) / sden;
+
+        // Principal ray intersection with the plane
+        T s0 = ns.z();
+        T mx0 = as.z() / s0;
+        T my0 = bs.z() / s0;
+
+        // Distortion in plane coordinates
+        Eigen::Matrix<T,2,1> dxy(mx - mx0, my - my0);
+        dxy = camera.distortion.distort(dxy);
+        mx = dxy.x() + mx0;
+        my = dxy.y() + my0;
+
+        // Pixel mapping (no skew)
+        T u = T(camera.K.fx) * mx + T(camera.K.cx);
+        T v = T(camera.K.fy) * my + T(camera.K.cy);
+        return {u, v};
+    }
+};
+
+} // namespace vitavision
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -107,3 +107,13 @@ target_link_libraries(json_test
     PRIVATE nlohmann_json::nlohmann_json
 )
 gtest_discover_tests(json_test)
+
+# Test for Scheimpflug camera projection
+add_executable(scheimpflug_test scheimpflug_test.cpp)
+target_link_libraries(scheimpflug_test
+    PRIVATE calibration
+    PRIVATE GTest::gtest_main
+    PRIVATE GTest::gmock_main
+    PRIVATE Eigen3::Eigen
+)
+gtest_discover_tests(scheimpflug_test)

--- a/test/scheimpflug_test.cpp
+++ b/test/scheimpflug_test.cpp
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+#include <Eigen/Core>
+
+#include "calibration/scheimpflug.h"
+
+using namespace vitavision;
+
+TEST(ScheimpflugCamera, ZeroTiltMatchesPinhole) {
+    Camera cam;
+    cam.K.fx = 800; cam.K.fy = 820; cam.K.cx = 320; cam.K.cy = 240;
+    cam.distortion.forward = Eigen::VectorXd::Zero(2);
+    cam.distortion.inverse = Eigen::VectorXd::Zero(2);
+
+    ScheimpflugCamera sc(cam, 0.0, 0.0);
+
+    Eigen::Vector3d Xc(0.2, -0.1, 1.0);
+    Eigen::Vector2d uv_s = sc.project<double>(Xc);
+    Eigen::Vector2d uv_p = cam.project(Eigen::Vector2d(Xc.x()/Xc.z(), Xc.y()/Xc.z()));
+
+    EXPECT_NEAR(uv_s.x(), uv_p.x(), 1e-9);
+    EXPECT_NEAR(uv_s.y(), uv_p.y(), 1e-9);
+}
+
+TEST(ScheimpflugCamera, PrincipalRayStaysAtCenter) {
+    Camera cam;
+    cam.K.fx = 600; cam.K.fy = 600; cam.K.cx = 400; cam.K.cy = 300;
+    cam.distortion.forward = Eigen::VectorXd::Zero(2);
+    cam.distortion.inverse = Eigen::VectorXd::Zero(2);
+
+    ScheimpflugCamera sc(cam, 0.1, -0.2);
+
+    Eigen::Vector3d Xc(0.0, 0.0, 1.0);
+    Eigen::Vector2d uv = sc.project<double>(Xc);
+
+    EXPECT_NEAR(uv.x(), cam.K.cx, 1e-9);
+    EXPECT_NEAR(uv.y(), cam.K.cy, 1e-9);
+}
+

--- a/test/scheimpflug_test.cpp
+++ b/test/scheimpflug_test.cpp
@@ -14,25 +14,32 @@ TEST(ScheimpflugCamera, ZeroTiltMatchesPinhole) {
     ScheimpflugCamera sc(cam, 0.0, 0.0);
 
     Eigen::Vector3d Xc(0.2, -0.1, 1.0);
-    Eigen::Vector2d uv_s = sc.project<double>(Xc);
-    Eigen::Vector2d uv_p = cam.project(Eigen::Vector2d(Xc.x()/Xc.z(), Xc.y()/Xc.z()));
+    Eigen::Vector2d uv_s = sc.project(Xc);
+    Eigen::Vector2d uv_p = cam.project(Xc);
 
     EXPECT_NEAR(uv_s.x(), uv_p.x(), 1e-9);
     EXPECT_NEAR(uv_s.y(), uv_p.y(), 1e-9);
 }
 
-TEST(ScheimpflugCamera, PrincipalRayStaysAtCenter) {
+TEST(ScheimpflugCamera, PrincipalRay) {
     Camera cam;
     cam.K.fx = 600; cam.K.fy = 600; cam.K.cx = 400; cam.K.cy = 300;
     cam.distortion.forward = Eigen::VectorXd::Zero(2);
     cam.distortion.inverse = Eigen::VectorXd::Zero(2);
 
-    ScheimpflugCamera sc(cam, 0.1, -0.2);
+    const double taux = 0.1;
+    const double tauy = -0.2;
+    ScheimpflugCamera sc(cam, taux, tauy);
 
     Eigen::Vector3d Xc(0.0, 0.0, 1.0);
-    Eigen::Vector2d uv = sc.project<double>(Xc);
+    Eigen::Vector2d uv = sc.project(Xc);
 
-    EXPECT_NEAR(uv.x(), cam.K.cx, 1e-9);
-    EXPECT_NEAR(uv.y(), cam.K.cy, 1e-9);
+    Eigen::Vector2d expected_m0{
+        -std::tan(tauy) / std::cos(taux),
+        std::tan(taux)
+    };
+    const auto expected_uv = cam.project(expected_m0);
+
+    EXPECT_NEAR(uv.x(), expected_uv.x(), 1e-9);
+    EXPECT_NEAR(uv.y(), expected_uv.y(), 1e-9);
 }
-


### PR DESCRIPTION
## Summary
- add ScheimpflugCamera class modeling tilted sensor plane and projection
- add unit tests covering zero tilt and principal ray cases

## Testing
- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release` *(fails: Could not find a package configuration file provided by "Ceres")*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b20467921083328b381c1e98d4cce9