### PR TITLE
Refactor bundle optimizer to use Camera objects

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -61,7 +61,7 @@ int main(int argc, char** argv) {
             result = r;
         } else if (task == "bundle") {
             BundleInput in = cfg.at("input").get<BundleInput>();
-            auto r = optimize_bundle(in.observations, in.initial_intrinsics, in.init_g_T_r, in.init_c_T_r, in.init_b_T_t, in.options);
+            auto r = optimize_bundle(in.observations, in.initial_cameras, in.init_g_T_r, in.init_c_T_r, in.init_b_T_t, in.options);
             result = r;
         } else {
             std::cerr << "Unknown task: " << task << std::endl;

--- a/include/calibration/bundle.h
+++ b/include/calibration/bundle.h
@@ -6,7 +6,7 @@
 // eigen
 #include <Eigen/Geometry>
 
-#include "calibration/intrinsics.h"
+#include "calibration/camera.h"
 #include "calibration/planarpose.h"  // PlanarObservation
 
 namespace vitavision {
@@ -35,8 +35,7 @@ struct BundleOptions final {
 
 /** Result returned by hand-eye calibration. */
 struct BundleResult final {
-    std::vector<CameraMatrix> intrinsics;      ///< Estimated intrinsics per camera
-    std::vector<Eigen::VectorXd> distortions;  ///< Estimated distortion coefficients
+    std::vector<Camera> cameras;               ///< Estimated camera parameters per camera
     Eigen::Affine3d g_T_r;                     ///< Estimated reference camera -> gripper transforms
     std::vector<Eigen::Affine3d> c_T_r;        ///< Estimated reference->camera extrinsics
     Eigen::Affine3d b_T_t;                     ///< Pose of target in base frame
@@ -50,7 +49,7 @@ struct BundleResult final {
  * problem.  Supports single or multiple cameras and optional optimisation of
  * intrinsics and the target pose.
  * @param observations Set of observations with robot poses and target detections
- * @param initial_intrinsics Initial camera intrinsic parameters
+ * @param initial_cameras Initial camera parameters
  * @param init_g_T_r Initial estimate of hand-eye transformation
  * @param init_c_T_r Initial estimates of reference camera to camera transformations
  * @param init_b_T_t Initial estimate of base-to-target transformation
@@ -59,7 +58,7 @@ struct BundleResult final {
  */
 BundleResult optimize_bundle(
     const std::vector<BundleObservation>& observations,
-    const std::vector<CameraMatrix>& initial_intrinsics,
+    const std::vector<Camera>& initial_cameras,
     const Eigen::Affine3d& init_g_T_r,
     const std::vector<Eigen::Affine3d>& init_c_T_r = {},
     const Eigen::Affine3d& init_b_T_t = Eigen::Affine3d::Identity(),

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -108,6 +108,17 @@ target_link_libraries(json_test
 )
 gtest_discover_tests(json_test)
 
+# Test for bundle optimisation
+add_executable(optimize_bundle_test optimize_bundle_test.cpp)
+target_link_libraries(optimize_bundle_test
+    PRIVATE calibration
+    PRIVATE GTest::gtest_main
+    PRIVATE GTest::gmock_main
+    PRIVATE Eigen3::Eigen
+    PRIVATE Ceres::ceres
+)
+gtest_discover_tests(optimize_bundle_test)
+
 # Test for Scheimpflug camera projection
 add_executable(scheimpflug_test scheimpflug_test.cpp)
 target_link_libraries(scheimpflug_test

--- a/test/optimize_bundle_test.cpp
+++ b/test/optimize_bundle_test.cpp
@@ -1,0 +1,181 @@
+#include <gtest/gtest.h>
+
+#include "calibration/bundle.h"
+#include "calibration/camera.h"
+#include <numbers>
+#include <cmath>
+
+using namespace vitavision;
+
+static PlanarView make_view(const std::vector<Eigen::Vector2d>& obj,
+                            const std::vector<Eigen::Vector2d>& img) {
+    PlanarView view(obj.size());
+    for (size_t i = 0; i < obj.size(); ++i) {
+        view[i].object_xy = obj[i];
+        view[i].image_uv = img[i];
+    }
+    return view;
+}
+
+static Eigen::Affine3d compute_camera_T_target(
+    const Eigen::Affine3d& b_T_t,
+    const Eigen::Affine3d& g_T_r,
+    const Eigen::Affine3d& c_T_r,
+    const Eigen::Affine3d& b_T_g) {
+    Eigen::Affine3d c_T_g = c_T_r * g_T_r.inverse();
+    Eigen::Affine3d c_T_b = c_T_g * b_T_g.inverse();
+    return c_T_b * b_T_t;
+}
+
+TEST(OptimizeBundle, SingleCameraHandEye) {
+    CameraMatrix K{100.0,100.0,64.0,48.0};
+    Camera cam(K, Eigen::VectorXd::Zero(5));
+
+    Eigen::Affine3d g_T_r = Eigen::Affine3d::Identity();
+    g_T_r.linear() = Eigen::AngleAxisd(0.05, Eigen::Vector3d::UnitY()).toRotationMatrix();
+    g_T_r.translation() = Eigen::Vector3d(0.1,0.0,0.05);
+
+    Eigen::Affine3d b_T_t = Eigen::Affine3d::Identity();
+    b_T_t.translation() = Eigen::Vector3d(0.2,0.0,0.0);
+
+    std::vector<Eigen::Vector2d> obj{{-0.1,-0.1},{0.1,-0.1},{0.1,0.1},{-0.1,0.1},
+                                     {0.5,0.5},{-1.0,-1.0},{2.0,2.0},{2.5,0.5}};
+
+    std::vector<BundleObservation> observations;
+    for (int i=0;i<8;++i){
+        double angle = i * std::numbers::pi/4.0;
+        Eigen::Affine3d b_T_g = Eigen::Affine3d::Identity();
+        b_T_g.translation() = Eigen::Vector3d(0.1*std::cos(angle),0.1*std::sin(angle),0.3+0.05*i);
+        Eigen::Matrix3d rot = Eigen::AngleAxisd(0.1*i, Eigen::Vector3d(std::cos(angle),std::sin(angle),0.5).normalized()).toRotationMatrix();
+        b_T_g.linear() = rot;
+
+        Eigen::Affine3d c_T_t = compute_camera_T_target(b_T_t, g_T_r, Eigen::Affine3d::Identity(), b_T_g);
+        std::vector<Eigen::Vector2d> img; img.reserve(obj.size());
+        for (const auto& xy: obj){
+            Eigen::Vector3d P(xy.x(),xy.y(),0.0);
+            P = c_T_t * P;
+            Eigen::Vector2d uv = cam.project(P);
+            img.push_back(uv);
+        }
+        observations.push_back({make_view(obj,img), b_T_g, 0});
+    }
+
+    std::vector<Camera> cams{cam};
+    Eigen::Affine3d init_g_T_r = g_T_r;
+    init_g_T_r.translation() += Eigen::Vector3d(0.01,-0.01,0.02);
+
+    BundleOptions opts; opts.optimize_intrinsics=false; opts.optimize_target_pose=false; opts.optimize_hand_eye=true; opts.optimize_extrinsics=false;
+
+    auto res = optimize_bundle(observations, cams, init_g_T_r, {Eigen::Affine3d::Identity()}, b_T_t, opts);
+
+    EXPECT_LT((res.g_T_r.translation()-g_T_r.translation()).norm(),1e-3);
+    Eigen::AngleAxisd diff(res.g_T_r.linear()*g_T_r.linear().transpose());
+    EXPECT_LT(diff.angle(),1e-3);
+    EXPECT_LT(res.reprojection_error,1e-9);
+}
+
+TEST(OptimizeBundle, SingleCameraTargetPose) {
+    CameraMatrix K{100.0,100.0,64.0,48.0};
+    Camera cam(K, Eigen::VectorXd::Zero(5));
+    Eigen::Affine3d g_T_r = Eigen::Affine3d::Identity();
+    g_T_r.linear() = Eigen::AngleAxisd(0.05, Eigen::Vector3d::UnitY()).toRotationMatrix();
+    g_T_r.translation() = Eigen::Vector3d(0.1,0.0,0.05);
+    Eigen::Affine3d b_T_t = Eigen::Affine3d::Identity();
+    b_T_t.translation() = Eigen::Vector3d(0.2,0.0,0.0);
+
+    std::vector<Eigen::Vector2d> obj{{-0.1,-0.1},{0.1,-0.1},{0.1,0.1},{-0.1,0.1},
+                                     {0.5,0.5},{-1.0,-1.0},{2.0,2.0},{2.5,0.5}};
+    std::vector<BundleObservation> observations;
+    for(int i=0;i<8;++i){
+        double angle = i * std::numbers::pi/4.0;
+        Eigen::Affine3d b_T_g = Eigen::Affine3d::Identity();
+        b_T_g.translation() = Eigen::Vector3d(0.1*std::cos(angle),0.1*std::sin(angle),0.3+0.05*i);
+        Eigen::Matrix3d rot = Eigen::AngleAxisd(0.1*i, Eigen::Vector3d(std::cos(angle),std::sin(angle),0.5).normalized()).toRotationMatrix();
+        b_T_g.linear() = rot;
+        Eigen::Affine3d c_T_t = compute_camera_T_target(b_T_t,g_T_r,Eigen::Affine3d::Identity(),b_T_g);
+        std::vector<Eigen::Vector2d> img; img.reserve(obj.size());
+        for(const auto& xy:obj){
+            Eigen::Vector3d P(xy.x(),xy.y(),0.0);
+            P = c_T_t * P;
+            img.push_back(cam.project(P));
+        }
+        observations.push_back({make_view(obj,img), b_T_g,0});
+    }
+
+    std::vector<Camera> cams{cam};
+    Eigen::Affine3d init_b_T_t = b_T_t;
+    init_b_T_t.translation() += Eigen::Vector3d(0.01,-0.02,0.03);
+
+    BundleOptions opts; opts.optimize_intrinsics=false; opts.optimize_target_pose=true; opts.optimize_hand_eye=false; opts.optimize_extrinsics=false;
+
+    auto res = optimize_bundle(observations, cams, g_T_r, {Eigen::Affine3d::Identity()}, init_b_T_t, opts);
+
+    EXPECT_LT((res.b_T_t.translation()-b_T_t.translation()).norm(),1e-3);
+    Eigen::AngleAxisd diff(res.b_T_t.linear()*b_T_t.linear().transpose());
+    EXPECT_LT(diff.angle(),1e-3);
+}
+
+TEST(OptimizeBundle, TwoCamerasHandEyeExtrinsics) {
+    CameraMatrix K{100.0,100.0,64.0,48.0};
+    Camera cam0(K, Eigen::VectorXd::Zero(5));
+    Camera cam1(K, Eigen::VectorXd::Zero(5));
+
+    Eigen::Affine3d g_T_r = Eigen::Affine3d::Identity();
+    g_T_r.linear() = Eigen::AngleAxisd(0.05, Eigen::Vector3d::UnitY()).toRotationMatrix();
+    g_T_r.translation() = Eigen::Vector3d(0.1,0.0,0.05);
+
+    Eigen::Affine3d c1_T_r = Eigen::Affine3d::Identity();
+    c1_T_r.translation() = Eigen::Vector3d(0.05,0.0,0.0);
+    c1_T_r.linear() = Eigen::AngleAxisd(0.1, Eigen::Vector3d::UnitZ()).toRotationMatrix();
+
+    Eigen::Affine3d b_T_t = Eigen::Affine3d::Identity();
+    b_T_t.translation() = Eigen::Vector3d(0.2,0.0,0.0);
+
+    std::vector<Eigen::Vector2d> obj{{-0.1,-0.1},{0.1,-0.1},{0.1,0.1},{-0.1,0.1},
+                                     {0.5,0.5},{-1.0,-1.0},{2.0,2.0},{2.5,0.5}};
+
+    std::vector<BundleObservation> observations;
+    for(int i=0;i<5;++i){
+        double angle = i * std::numbers::pi/5.0;
+        Eigen::Affine3d b_T_g = Eigen::Affine3d::Identity();
+        b_T_g.translation() = Eigen::Vector3d(0.1*std::cos(angle),0.1*std::sin(angle),0.3+0.05*i);
+        Eigen::Matrix3d rot = Eigen::AngleAxisd(0.1*i, Eigen::Vector3d(std::cos(angle),std::sin(angle),0.5).normalized()).toRotationMatrix();
+        b_T_g.linear() = rot;
+
+        Eigen::Affine3d c0_T_t = compute_camera_T_target(b_T_t,g_T_r,Eigen::Affine3d::Identity(),b_T_g);
+        Eigen::Affine3d c1_T_t = compute_camera_T_target(b_T_t,g_T_r,c1_T_r,b_T_g);
+        std::vector<Eigen::Vector2d> img0_vec; img0_vec.reserve(obj.size());
+        for(const auto& xy:obj){
+            Eigen::Vector3d P(xy.x(),xy.y(),0.0);
+            P = c0_T_t * P;
+            img0_vec.push_back(cam0.project(P));
+        }
+        observations.push_back({make_view(obj,img0_vec), b_T_g,0});
+        std::vector<Eigen::Vector2d> img1_vec; img1_vec.reserve(obj.size());
+        for(const auto& xy:obj){
+            Eigen::Vector3d P(xy.x(),xy.y(),0.0);
+            P = c1_T_t * P;
+            img1_vec.push_back(cam1.project(P));
+        }
+        observations.push_back({make_view(obj,img1_vec), b_T_g,1});
+    }
+
+    std::vector<Camera> cams{cam0,cam1};
+    std::vector<Eigen::Affine3d> init_c_T_r{Eigen::Affine3d::Identity(), c1_T_r};
+    init_c_T_r[1].translation() += Eigen::Vector3d(0.01,-0.01,0.0);
+    init_c_T_r[1].linear() = Eigen::AngleAxisd(0.09, Eigen::Vector3d::UnitZ()).toRotationMatrix();
+    Eigen::Affine3d init_g_T_r = g_T_r;
+    init_g_T_r.translation() += Eigen::Vector3d(-0.01,0.02,-0.02);
+
+    BundleOptions opts; opts.optimize_intrinsics=false; opts.optimize_target_pose=false; opts.optimize_hand_eye=true; opts.optimize_extrinsics=true;
+
+    auto res = optimize_bundle(observations, cams, init_g_T_r, init_c_T_r, b_T_t, opts);
+
+    EXPECT_LT((res.g_T_r.translation()-g_T_r.translation()).norm(),1e-3);
+    Eigen::AngleAxisd diff(res.g_T_r.linear()*g_T_r.linear().transpose());
+    EXPECT_LT(diff.angle(),1e-3);
+    EXPECT_LT((res.c_T_r[1].translation()-c1_T_r.translation()).norm(),1e-3);
+    Eigen::AngleAxisd diff2(res.c_T_r[1].linear()*c1_T_r.linear().transpose());
+    EXPECT_LT(diff2.angle(),1e-3);
+}
+

--- a/test/optimize_bundle_test.cpp
+++ b/test/optimize_bundle_test.cpp
@@ -1,9 +1,10 @@
 #include <gtest/gtest.h>
 
-#include "calibration/bundle.h"
-#include "calibration/camera.h"
+// std
 #include <numbers>
 #include <cmath>
+
+#include "calibration/bundle.h"
 
 using namespace vitavision;
 
@@ -71,7 +72,7 @@ TEST(OptimizeBundle, SingleCameraHandEye) {
     EXPECT_LT((res.g_T_r.translation()-g_T_r.translation()).norm(),1e-3);
     Eigen::AngleAxisd diff(res.g_T_r.linear()*g_T_r.linear().transpose());
     EXPECT_LT(diff.angle(),1e-3);
-    EXPECT_LT(res.reprojection_error,1e-9);
+    EXPECT_LT(res.reprojection_error, 0.01);
 }
 
 TEST(OptimizeBundle, SingleCameraTargetPose) {
@@ -178,4 +179,3 @@ TEST(OptimizeBundle, TwoCamerasHandEyeExtrinsics) {
     Eigen::AngleAxisd diff2(res.c_T_r[1].linear()*c1_T_r.linear().transpose());
     EXPECT_LT(diff2.angle(),1e-3);
 }
-


### PR DESCRIPTION
## Summary
- refactor bundle calibration to operate on `Camera` instead of `CameraMatrix`
- update serialization, CLI glue and result structures for new `Camera` usage
- add comprehensive tests for `optimize_bundle` covering hand-eye, target pose, and multi-camera extrinsics

## Testing
- `cmake -B build` *(fails: Could not find a package configuration file provided by "Ceres")*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*
- `cd build && ctest` *(fails: No test configuration file found)*


------
https://chatgpt.com/codex/tasks/task_e_68b2ae016fb883329c316128d59cf372