### PR TITLE
Link Ceres publicly to fix Windows tests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,7 @@ target_include_directories(${TARGET} PUBLIC
 )
 
 target_link_libraries(${TARGET} PUBLIC Eigen3::Eigen)
-target_link_libraries(${TARGET} PRIVATE Ceres::ceres)
+target_link_libraries(${TARGET} PUBLIC Ceres::ceres)
 target_link_libraries(${TARGET} PUBLIC nlohmann_json::nlohmann_json)
 
 # set max warning level if unix, warnings as errors


### PR DESCRIPTION
## Summary
- Link the calibration library to Ceres as a public dependency so downstream targets inherit necessary include directories and compile definitions.
- This allows Windows builds to include `glog/logging.h` correctly when tests include Ceres headers.

## Testing
- ⚠️ `cmake -S . -B build` *(fails: Could not find package configuration file provided by "Ceres")*

------
https://chatgpt.com/codex/tasks/task_e_68b45366ff908332863f288693c3b6a9