### PR TITLE
Add skew parameter support to calibration routines

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,117 @@
+# Calibration Library - AI Assistant Instructions
+
+## Project Overview
+
+This is a C++ camera calibration library focusing on geometric computer vision algorithms. The library provides modular components for:
+- Camera intrinsic/extrinsic calibration from planar targets
+- Distortion correction and modeling
+- Hand-eye calibration with bundle adjustment (single/multi-camera)
+- Homography estimation and pose computation
+
+## Architecture & Key Components
+
+### Core Module Structure
+```
+include/calib/          # Public headers (lightweight APIs)
+├── calib.h            # Main calibration entry point
+├── handeye.h          # Hand-eye calibration algorithms
+├── bundle.h           # Bundle adjustment for multi-camera systems
+├── planarpose.h       # Planar target pose estimation
+├── intrinsics.h       # Camera intrinsic parameter estimation
+├── distortion.h       # Lens distortion models with concepts
+├── cameramatrix.h     # Camera intrinsic parameter representation
+└── serialization.h    # JSON I/O for all data structures
+
+src/                   # Implementation files
+├── *residual.h        # Ceres cost function implementations
+└── observationutils.h # Internal utilities for optimization
+```
+
+### Data Flow Pattern
+1. **Observations** → `PlanarView` (vector of `PlanarObservation`)
+2. **Initial Estimates** → DLT/linear methods (e.g., `estimate_planar_pose_dlt`)
+3. **Refinement** → Ceres-based bundle adjustment
+4. **Results** → Structured result types with covariance and error metrics
+
+## Development Patterns
+
+### Template-Based Design
+- Heavy use of templated functions for scalar type flexibility (`float`/`double`)
+- C++20 concepts for distortion models: `distortion_model` concept
+- Template specialization in headers for compile-time optimization
+
+### JSON Serialization Convention
+- Automatic serialization using Boost.PFR reflection for aggregate types
+- Manual `to_json`/`from_json` for complex types in `serialization.h`
+- All result structures are JSON-serializable for CLI tool integration
+
+### Ceres Optimization Pattern
+- Custom residual structs in `*residual.h` files (e.g., `handeyeresidual.h`)
+- Variable projection for non-linear problems
+- Consistent use of `Eigen::Affine3d` for 3D transformations
+- Robust loss functions (Huber) with configurable deltas
+
+### Error Handling
+- `std::optional` return types for algorithms that may fail
+- Result structures include error metrics (`reprojection_error`, `view_errors`)
+- Covariance matrices provided for uncertainty quantification
+
+## Build & Test Workflow
+
+### Standard Build Commands
+```bash
+# Configure (from repo root)
+cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+
+# Build
+cmake --build build -j2
+
+# Test
+cd build && ctest
+
+# Run example
+./build/examples/homography < input_data.txt
+```
+
+### Dependencies (managed via system packages or vcpkg)
+- **Eigen3**: Core linear algebra (all algorithms heavily dependent)
+- **Ceres**: Non-linear optimization engine
+- **nlohmann::json**: JSON I/O throughout
+- **CLI11**: Command-line parsing for `calib_app`
+- **GoogleTest/GMock**: Testing framework
+- **Boost.PFR**: Reflection for automatic JSON serialization
+
+### Testing Patterns
+- Each component has dedicated test file: `*_test.cpp`
+- Tests use synthetic data generation with known ground truth
+- Error tolerance testing with `EXPECT_LT(error, threshold)`
+- Noise robustness testing in optimization algorithms
+
+## Key Integration Points
+
+### Command-Line Application (`app/`)
+- JSON-driven configuration via `AppConfig` struct
+- Task-based execution: `intrinsics`, `extrinsics`, `handeye`, etc.
+- CLI11 for argument parsing with config file overrides
+
+### Camera Model Abstraction
+- `CameraMatrix` for intrinsic parameters (fx, fy, cx, cy, skew)
+- Templated `normalize()`/`denormalize()` methods for coordinate transforms
+- Support for various distortion models through concept-based design
+
+### Bundle Adjustment Architecture
+- `BundleObservation` links robot poses (`b_T_g`) with camera views
+- Multi-camera support via `camera_index` and relative `extrinsics`
+- Configurable optimization via `BundleOptions` (what to optimize)
+
+## Common Pitfalls & Project-Specific Notes
+
+- **Coordinate Conventions**: World→camera transformations, Z=0 for planar targets
+- **Template Instantiation**: Many algorithms require explicit template parameter specification
+- **JSON Schema**: Use existing serialization in `serialization.h` rather than manual JSON handling
+- **Ceres Integration**: Always use provided residual classes rather than writing raw cost functions
+- **Error Handling**: Check `std::optional` returns before using results
+- **Memory Layout**: Eigen matrices are column-major by default (affects Ceres parameter blocks)
+
+## Documentation
+Detailed algorithm documentation available in `doc/` directory with separate markdown files per component.

--- a/README.md
+++ b/README.md
@@ -79,19 +79,7 @@ cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release `
 cmake --build build --config Release -j2
 ```
 
-Run a smoke test:
-
-```powershell
-build\examples\homography.exe <<EOF
-4
-0   0    10 20
-100 0    110 18
-100 50   120 70
-0   50   8  72
-EOF
-```
-
-## Usage
+## Usage *TODO: update this section*
 
 The library exposes lightweight C++ APIs.  The most common entry points are:
 

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -45,10 +45,10 @@ int main(int argc, char** argv) {
             IntrinsicsInput in = cfg.at("input").get<IntrinsicsInput>();
             CameraMatrix guess{1000,1000,640,360};
             if (!in.observations.empty()) {
-                auto init = estimate_intrinsics_linear_iterative(in.observations, in.num_radial, 5);
+                auto init = estimate_intrinsics_linear_iterative(in.observations, in.num_radial, 5, false);
                 if (init) guess = init->camera.K;
             }
-            IntrinsicOptimizationResult r = optimize_intrinsics(in.observations, in.num_radial, guess);
+            IntrinsicOptimizationResult r = optimize_intrinsics(in.observations, in.num_radial, guess, false, std::nullopt, false);
             result = r;
         } else if (task == "extrinsics") {
             ExtrinsicsInput in = cfg.at("input").get<ExtrinsicsInput>();

--- a/include/calib/bundle.h
+++ b/include/calib/bundle.h
@@ -34,6 +34,7 @@ enum class OptimizerType {
 };
 
 /** Options controlling the hand-eye calibration optimisation. */
+// TODO: add optimize_distortion
 struct BundleOptions final {
     bool optimize_intrinsics = false;  ///< Solve for camera intrinsics
     bool optimize_skew = false;        ///< Solve for skew parameter

--- a/include/calib/bundle.h
+++ b/include/calib/bundle.h
@@ -36,6 +36,7 @@ enum class OptimizerType {
 /** Options controlling the hand-eye calibration optimisation. */
 struct BundleOptions final {
     bool optimize_intrinsics = false;  ///< Solve for camera intrinsics
+    bool optimize_skew = false;        ///< Solve for skew parameter
     bool optimize_target_pose = true;  ///< Solve for base->target pose
     bool optimize_hand_eye = true;     ///< Solve for camera->gripper poses
     double huber_delta = 1.0;          ///< Huber loss delta

--- a/include/calib/camera.h
+++ b/include/calib/camera.h
@@ -66,13 +66,13 @@ using PinholeCamera = Camera<DualDistortion>;
 // Camera traits specialisation for generic pinhole camera
 template<distortion_model DistortionT>
 struct CameraTraits<Camera<DistortionT>> {
-    static constexpr size_t param_count = 9;
+    static constexpr size_t param_count = 10;
 
     template<typename T>
     static Camera<BrownConrady<T>> from_array(const T* intr) {
-        CameraMatrixT<T> K{intr[0], intr[1], intr[2], intr[3]};
+        CameraMatrixT<T> K{intr[0], intr[1], intr[2], intr[3], intr[4]};
         Eigen::Matrix<T, Eigen::Dynamic, 1> dist(5);
-        dist << intr[4], intr[5], intr[6], intr[7], intr[8];
+        dist << intr[5], intr[6], intr[7], intr[8], intr[9];
         return Camera<BrownConrady<T>>(K, dist);
     }
 
@@ -80,7 +80,8 @@ struct CameraTraits<Camera<DistortionT>> {
                          std::array<double, param_count>& arr) {
         arr[0] = cam.K.fx; arr[1] = cam.K.fy;
         arr[2] = cam.K.cx; arr[3] = cam.K.cy;
-        for (int i = 0; i < 5; ++i) arr[4 + i] = cam.distortion.coeffs[i];
+        arr[4] = cam.K.skew;
+        for (int i = 0; i < 5; ++i) arr[5 + i] = cam.distortion.coeffs[i];
     }
 };
 

--- a/include/calib/cameramatrix.h
+++ b/include/calib/cameramatrix.h
@@ -12,6 +12,7 @@ namespace calib {
 template<typename Scalar>
 struct CameraMatrixT final {
     Scalar fx, fy, cx, cy;
+    Scalar skew = Scalar(0);
 
     /**
      * @brief Normalizes a 2D pixel coordinate using the intrinsic camera parameters.
@@ -27,10 +28,9 @@ struct CameraMatrixT final {
      */
     template<typename T>
     Eigen::Matrix<T,2,1> normalize(const Eigen::Matrix<T,2,1>& pix) const {
-        return {
-            (pix.x() - T(cx)) / T(fx),
-            (pix.y() - T(cy)) / T(fy)
-        };
+        T y = (pix.y() - T(cy)) / T(fy);
+        T x = (pix.x() - T(cx) - T(skew) * y) / T(fx);
+        return {x, y};
     }
 
     /**
@@ -46,7 +46,7 @@ struct CameraMatrixT final {
     template<typename T>
     Eigen::Matrix<T,2,1> denormalize(const Eigen::Matrix<T,2,1>& xy) const {
         return {
-            T(fx) * xy.x() + T(cx),
+            T(fx) * xy.x() + T(skew) * xy.y() + T(cx),
             T(fy) * xy.y() + T(cy)
         };
     }
@@ -63,6 +63,8 @@ struct CalibrationBounds final {
     double cx_max = 1280.0;
     double cy_min = 10.0;
     double cy_max = 720.0;
+    double skew_min = -500.0;
+    double skew_max = 500.0;
 };
 
 } // namespace calib

--- a/include/calib/cameramatrix.h
+++ b/include/calib/cameramatrix.h
@@ -55,16 +55,16 @@ struct CameraMatrixT final {
 using CameraMatrix = CameraMatrixT<double>;
 
 struct CalibrationBounds final {
-    double fx_min = 100.0;
+    double fx_min = 0;
     double fx_max = 2000.0;
-    double fy_min = 100.0;
+    double fy_min = 0;
     double fy_max = 2000.0;
-    double cx_min = 10.0;
+    double cx_min = 0;
     double cx_max = 1280.0;
-    double cy_min = 10.0;
+    double cy_min = 0;
     double cy_max = 720.0;
-    double skew_min = -500.0;
-    double skew_max = 500.0;
+    double skew_min = -0.01;
+    double skew_max =  0.01;
 };
 
 } // namespace calib

--- a/include/calib/intrinsics.h
+++ b/include/calib/intrinsics.h
@@ -17,7 +17,7 @@ namespace calib {
 
 struct IntrinsicOptimizationResult {
     Camera<DualDistortion> camera;
-    Eigen::Matrix4d covariance;  // Covariance matrix of intrinsics
+    Eigen::Matrix<double,5,5> covariance;  // Covariance matrix of intrinsics
     double reprojection_error;   // Reprojection error after optimization (pix)
     std::string summary;         // Summary of optimization results
 };
@@ -28,7 +28,7 @@ struct LinearInitResult {
     Camera<DualDistortion> camera;
 };
 
-// Estimate camera intrinsics (fx, fy, cx, cy) by solving a linear
+// Estimate camera intrinsics (fx, fy, cx, cy[, skew]) by solving a linear
 // least-squares system that ignores lens distortion.  The input
 // observations contain normalized coordinates (x,y) for an undistorted
 // point and the observed pixel coordinates (u,v).  The function returns
@@ -36,7 +36,8 @@ struct LinearInitResult {
 // enough observations or the linear system is degenerate.
 std::optional<CameraMatrix> estimate_intrinsics_linear(
     const std::vector<Observation<double>>& obs,
-    std::optional<CalibrationBounds> bounds = std::nullopt);
+    std::optional<CalibrationBounds> bounds = std::nullopt,
+    bool use_skew = false);
 
 // Improved linear initialization that alternates between estimating
 // distortion coefficients (fit_distortion) and re-solving for camera
@@ -46,14 +47,16 @@ std::optional<CameraMatrix> estimate_intrinsics_linear(
 std::optional<LinearInitResult> estimate_intrinsics_linear_iterative(
     const std::vector<Observation<double>>& obs,
     int num_radial,
-    int max_iterations = 5);
+    int max_iterations = 5,
+    bool use_skew = false);
 
 IntrinsicOptimizationResult optimize_intrinsics(
     const std::vector<Observation<double>>& obs,
     int num_radial,
     const CameraMatrix& initial_guess,
     bool verb=false,
-    std::optional<CalibrationBounds> bounds = std::nullopt
+    std::optional<CalibrationBounds> bounds = std::nullopt,
+    bool use_skew = false
 );
 
 }  // namespace calib

--- a/include/calib/intrinsics.h
+++ b/include/calib/intrinsics.h
@@ -15,6 +15,7 @@
 
 namespace calib {
 
+// TODO: make distortion model a template parameter
 struct IntrinsicOptimizationResult {
     Camera<DualDistortion> camera;
     Eigen::Matrix<double,5,5> covariance;  // Covariance matrix of intrinsics

--- a/include/calib/jointintrextr.h
+++ b/include/calib/jointintrextr.h
@@ -9,7 +9,7 @@ struct JointOptimizationResult final {
     std::vector<Eigen::VectorXd> distortions;                   // Estimated distortion coeffs
     std::vector<Eigen::Affine3d> camera_poses;                  // reference->camera
     std::vector<Eigen::Affine3d> target_poses;                  // target->reference
-    std::vector<Eigen::Matrix4d> intrinsic_covariances;         // Covariance of intrinsics
+    std::vector<Eigen::Matrix<double,5,5>> intrinsic_covariances;         // Covariance of intrinsics
     std::vector<Eigen::Matrix<double,6,6>> camera_covariances;  // Covariance of camera poses
     std::vector<Eigen::Matrix<double,6,6>> target_covariances;  // Covariance of target poses
     double reprojection_error = 0.0;                            // RMS pixel error

--- a/include/calib/serialization.h
+++ b/include/calib/serialization.h
@@ -85,7 +85,7 @@ void from_json(const nlohmann::json& j, Observation<T>& o) {
 }
 
 inline void to_json(nlohmann::json& j, const CameraMatrix& c) {
-    j = {{"fx", c.fx}, {"fy", c.fy}, {"cx", c.cx}, {"cy", c.cy}};
+    j = {{"fx", c.fx}, {"fy", c.fy}, {"cx", c.cx}, {"cy", c.cy}, {"skew", c.skew}};
 }
 
 inline void from_json(const nlohmann::json& j, CameraMatrix& c) {
@@ -93,6 +93,7 @@ inline void from_json(const nlohmann::json& j, CameraMatrix& c) {
     j.at("fy").get_to(c.fy);
     j.at("cx").get_to(c.cx);
     j.at("cy").get_to(c.cy);
+    c.skew = j.value("skew", 0.0);
 }
 
 inline void to_json(nlohmann::json& j, const DualDistortion& d) {
@@ -145,6 +146,7 @@ inline void from_json(const nlohmann::json& j, PlanarObservation& p) {
 inline void to_json(nlohmann::json& j, const BundleOptions& o) {
     j = {
         {"optimize_intrinsics", o.optimize_intrinsics},
+        {"optimize_skew", o.optimize_skew},
         {"optimize_target_pose", o.optimize_target_pose},
         {"optimize_hand_eye", o.optimize_hand_eye},
         {"verbose", o.verbose}
@@ -153,6 +155,7 @@ inline void to_json(nlohmann::json& j, const BundleOptions& o) {
 
 inline void from_json(const nlohmann::json& j, BundleOptions& o) {
     o.optimize_intrinsics = j.value("optimize_intrinsics", false);
+    o.optimize_skew = j.value("optimize_skew", false);
     o.optimize_target_pose = j.value("optimize_target_pose", true);
     o.optimize_hand_eye = j.value("optimize_hand_eye", true);
     o.verbose = j.value("verbose", false);

--- a/src/bundle.cpp
+++ b/src/bundle.cpp
@@ -88,6 +88,11 @@ static ceres::Problem build_problem(
         for (size_t c = 0; c < blocks.intr.size(); ++c) {
             p.SetParameterLowerBound(blocks.intr[c].data(), 0, 0.0);
             p.SetParameterLowerBound(blocks.intr[c].data(), 1, 0.0);
+            if (!opts.optimize_skew) {
+                double s = blocks.intr[c][4];
+                p.SetParameterLowerBound(blocks.intr[c].data(), 4, s);
+                p.SetParameterUpperBound(blocks.intr[c].data(), 4, s);
+            }
         }
     }
     return p;

--- a/src/bundle.cpp
+++ b/src/bundle.cpp
@@ -89,9 +89,7 @@ static ceres::Problem build_problem(
             p.SetParameterLowerBound(blocks.intr[c].data(), 0, 0.0);
             p.SetParameterLowerBound(blocks.intr[c].data(), 1, 0.0);
             if (!opts.optimize_skew) {
-                double s = blocks.intr[c][4];
-                p.SetParameterLowerBound(blocks.intr[c].data(), 4, s);
-                p.SetParameterUpperBound(blocks.intr[c].data(), 4, s);
+                p.SetManifold(blocks.intr[c].data(), new ceres::SubsetManifold(BundleBlocks<CameraT>::IntrSize, {4}));
             }
         }
     }

--- a/src/calib.cpp
+++ b/src/calib.cpp
@@ -43,7 +43,7 @@ struct CalibVPResidual {
             }
         }
 
-        auto dr = fit_distortion_full(o, intr[0], intr[1], intr[2], intr[3], num_radial_);
+        auto dr = fit_distortion_full(o, intr[0], intr[1], intr[2], intr[3], intr[4], num_radial_);
         if (!dr) return false;
         const auto& r = dr->residuals;
         for (int i = 0; i < r.size(); ++i) residuals[i] = r[i];
@@ -75,7 +75,7 @@ static std::optional<DistortionWithResiduals<double>> solve_full(
             obs[obs_idx++] = to_observation(ob, pose6);
         }
     }
-    return fit_distortion_full(obs, intr[0], intr[1], intr[2], intr[3], num_radial);
+    return fit_distortion_full(obs, intr[0], intr[1], intr[2], intr[3], intr[4], num_radial);
 }
 
 static Eigen::Affine3d axisangle_to_pose(const Pose6& pose6) {
@@ -114,7 +114,7 @@ static void setup_optimization_problem(
 ) {
     auto* functor = new CalibVPResidual(obs_views, num_radial);
     auto* cost = new ceres::DynamicAutoDiffCostFunction(functor);
-    cost->AddParameterBlock(4);  // Intrinsics
+    cost->AddParameterBlock(5);  // Intrinsics
     for (size_t i = 0; i < poses.size(); ++i) {
         cost->AddParameterBlock(6);  // Pose for each view
     }
@@ -165,6 +165,7 @@ static void populate_result_parameters(
     result.intrinsics.fy = intrinsics[1];
     result.intrinsics.cx = intrinsics[2];
     result.intrinsics.cy = intrinsics[3];
+    result.intrinsics.skew = intrinsics[4];
 
     result.poses.resize(poses.size());
     for (size_t i = 0; i < poses.size(); ++i) {
@@ -256,7 +257,7 @@ CameraCalibrationResult calibrate_camera_planar(
     }
 
     // Initialize intrinsics and poses
-    double intrinsics[4] = {initial_guess.fx, initial_guess.fy, initial_guess.cx, initial_guess.cy};
+    double intrinsics[5] = {initial_guess.fx, initial_guess.fy, initial_guess.cx, initial_guess.cy, initial_guess.skew};
     std::vector<Pose6> poses(num_views);
     initialize_poses(views, initial_guess, poses);
 
@@ -287,11 +288,13 @@ CameraCalibrationResult calibrate_camera_planar(
     problem.SetParameterLowerBound(intrinsics, 1, bounds.fy_min);
     problem.SetParameterLowerBound(intrinsics, 2, bounds.cx_min);
     problem.SetParameterLowerBound(intrinsics, 3, bounds.cy_min);
+    problem.SetParameterLowerBound(intrinsics, 4, bounds.skew_min);
 
     problem.SetParameterUpperBound(intrinsics, 0, bounds.fx_max);
     problem.SetParameterUpperBound(intrinsics, 1, bounds.fy_max);
     problem.SetParameterUpperBound(intrinsics, 2, bounds.cx_max);
     problem.SetParameterUpperBound(intrinsics, 3, bounds.cy_max);
+    problem.SetParameterUpperBound(intrinsics, 4, bounds.skew_max);
 
     ceres::Solver::Summary summary;
     ceres::Solve(opts, &problem, &summary);
@@ -312,9 +315,9 @@ CameraCalibrationResult calibrate_camera_planar(
         populate_result_parameters(intrinsics, poses, result);
 
         // Compute covariance matrix
-        const size_t total_params = 4 + 6 * num_views;
+    const size_t total_params = 5 + 6 * num_views;
         std::vector<int> block_sizes;
-        block_sizes.push_back(4);  // Intrinsics block
+        block_sizes.push_back(5);  // Intrinsics block
         for (size_t i = 0; i < num_views; ++i) {
             block_sizes.push_back(6);  // Pose blocks
         }

--- a/src/calib.cpp
+++ b/src/calib.cpp
@@ -127,6 +127,7 @@ static void setup_optimization_problem(
         param_blocks.push_back(poses[i].data());
     }
     problem.AddResidualBlock(cost, nullptr, param_blocks);
+    problem.SetManifold(intrinsics, new ceres::SubsetManifold(5, {4}));  // fix skew
 }
 
 // Calculate reprojection errors overall and per view

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -12,74 +12,103 @@
 namespace calib {
 
 // Compute a linear least-squares estimate of the camera intrinsics
-// (fx, fy, cx, cy) from normalized correspondences.  This ignores lens
-// distortion and solves two independent systems:
-//   u = fx * x + cx
+// (fx, fy, cx, cy[, skew]) from normalized correspondences. This ignores lens
+// distortion and solves either two or three independent systems depending on
+// whether skew is estimated:
+//   u = fx * x + skew * y + cx
 //   v = fy * y + cy
 // If there are insufficient observations or the design matrix is
 // degenerate, std::nullopt is returned.
 std::optional<CameraMatrix> estimate_intrinsics_linear(
     const std::vector<Observation<double>>& obs,
-    std::optional<CalibrationBounds> bounds_opt) {
+    std::optional<CalibrationBounds> bounds_opt,
+    bool use_skew) {
     if (obs.size() < 2) {
         return std::nullopt;
     }
 
-    // Build separate design matrices for x and y coordinates
-    Eigen::MatrixXd Ax(obs.size(), 2);
     Eigen::MatrixXd Ay(obs.size(), 2);
-    Eigen::VectorXd bu(obs.size());
     Eigen::VectorXd bv(obs.size());
 
-    for (size_t i = 0; i < obs.size(); ++i) {
-        Ax(static_cast<int>(i), 0) = obs[i].x;
-        Ax(static_cast<int>(i), 1) = 1.0;
+    Eigen::VectorXd bu(obs.size());
+    Eigen::JacobiSVD<Eigen::MatrixXd> svd_x;
+    Eigen::VectorXd xu;
 
-        Ay(static_cast<int>(i), 0) = obs[i].y;
-        Ay(static_cast<int>(i), 1) = 1.0;
-
-        bu(static_cast<int>(i)) = obs[i].u;
-        bv(static_cast<int>(i)) = obs[i].v;
+    if (use_skew) {
+        Eigen::MatrixXd Ax(obs.size(), 3);
+        for (size_t i = 0; i < obs.size(); ++i) {
+            Ax(static_cast<int>(i), 0) = obs[i].x;
+            Ax(static_cast<int>(i), 1) = obs[i].y;
+            Ax(static_cast<int>(i), 2) = 1.0;
+            Ay(static_cast<int>(i), 0) = obs[i].y;
+            Ay(static_cast<int>(i), 1) = 1.0;
+            bu(static_cast<int>(i)) = obs[i].u;
+            bv(static_cast<int>(i)) = obs[i].v;
+        }
+        svd_x.compute(Ax, Eigen::ComputeThinU | Eigen::ComputeThinV);
+        if (svd_x.singularValues().minCoeff() < 1e-12) {
+            return std::nullopt;
+        }
+        xu = svd_x.solve(bu);
+    } else {
+        Eigen::MatrixXd Ax(obs.size(), 2);
+        for (size_t i = 0; i < obs.size(); ++i) {
+            Ax(static_cast<int>(i), 0) = obs[i].x;
+            Ax(static_cast<int>(i), 1) = 1.0;
+            Ay(static_cast<int>(i), 0) = obs[i].y;
+            Ay(static_cast<int>(i), 1) = 1.0;
+            bu(static_cast<int>(i)) = obs[i].u;
+            bv(static_cast<int>(i)) = obs[i].v;
+        }
+        svd_x.compute(Ax, Eigen::ComputeThinU | Eigen::ComputeThinV);
+        if (svd_x.singularValues().minCoeff() < 1e-12) {
+            return std::nullopt;
+        }
+        xu = svd_x.solve(bu);
     }
 
-    // Solve for fx, cx using x coordinates
-    Eigen::JacobiSVD<Eigen::MatrixXd> svd_x(Ax, Eigen::ComputeThinU | Eigen::ComputeThinV);
-    // Detect degenerate configuration
-    if (svd_x.singularValues().minCoeff() < 1e-12) {
-        return std::nullopt;
-    }
-
-    // Solve for fy, cy using y coordinates
     Eigen::JacobiSVD<Eigen::MatrixXd> svd_y(Ay, Eigen::ComputeThinU | Eigen::ComputeThinV);
-    // Detect degenerate configuration
     if (svd_y.singularValues().minCoeff() < 1e-12) {
         return std::nullopt;
     }
 
-    Eigen::Vector2d xu = svd_x.solve(bu);
     Eigen::Vector2d xv = svd_y.solve(bv);
 
     CalibrationBounds bounds = bounds_opt.value_or(CalibrationBounds{});
 
-    // Check for reasonably sized intrinsics
-    if (xu[0] < bounds.fx_min || xv[0] < bounds.fy_min ||
-        xu[0] > bounds.fx_max || xv[0] > bounds.fy_max ||
-        xu[1] < bounds.cx_min || xv[1] < bounds.cy_min ||
-        xu[1] > bounds.cx_max || xv[1] > bounds.cy_max) {
-        std::cerr << "Warning: Linear calibration produced unreasonable intrinsics: fx="
-                  << xu[0] << ", fy=" << xv[0] << ", cx=" << xu[1]
-                  << ", cy=" << xv[1] << std::endl;
-        // Use reasonable defaults based on resolution
-        double avg_u = bu.sum() / obs.size();
-        double avg_v = bv.sum() / obs.size();
-        xu[0] = std::clamp(std::max(500.0, xu[0]), bounds.fx_min, bounds.fx_max);
-        xv[0] = std::clamp(std::max(500.0, xv[0]), bounds.fy_min, bounds.fy_max);
-        xu[1] = std::clamp(avg_u / 2.0, bounds.cx_min, bounds.cx_max);
-        xv[1] = std::clamp(avg_v / 2.0, bounds.cy_min, bounds.cy_max);
+    if (use_skew) {
+        if (xu[0] < bounds.fx_min || xv[0] < bounds.fy_min ||
+            xu[0] > bounds.fx_max || xv[0] > bounds.fy_max ||
+            xu[2] < bounds.cx_min || xv[1] < bounds.cy_min ||
+            xu[2] > bounds.cx_max || xv[1] > bounds.cy_max ||
+            xu[1] < bounds.skew_min || xu[1] > bounds.skew_max) {
+            std::cerr << "Warning: Linear calibration produced unreasonable intrinsics\n";
+            double avg_u = bu.sum() / obs.size();
+            double avg_v = bv.sum() / obs.size();
+            xu[0] = std::clamp(std::max(500.0, xu[0]), bounds.fx_min, bounds.fx_max);
+            xv[0] = std::clamp(std::max(500.0, xv[0]), bounds.fy_min, bounds.fy_max);
+            xu[2] = std::clamp(avg_u / 2.0, bounds.cx_min, bounds.cx_max);
+            xv[1] = std::clamp(avg_v / 2.0, bounds.cy_min, bounds.cy_max);
+            xu[1] = std::clamp(xu[1], bounds.skew_min, bounds.skew_max);
+        }
+        CameraMatrix K{xu[0], xv[0], xu[2], xv[1], xu[1]};
+        return K;
+    } else {
+        if (xu[0] < bounds.fx_min || xv[0] < bounds.fy_min ||
+            xu[0] > bounds.fx_max || xv[0] > bounds.fy_max ||
+            xu[1] < bounds.cx_min || xv[1] < bounds.cy_min ||
+            xu[1] > bounds.cx_max || xv[1] > bounds.cy_max) {
+            std::cerr << "Warning: Linear calibration produced unreasonable intrinsics\n";
+            double avg_u = bu.sum() / obs.size();
+            double avg_v = bv.sum() / obs.size();
+            xu[0] = std::clamp(std::max(500.0, xu[0]), bounds.fx_min, bounds.fx_max);
+            xv[0] = std::clamp(std::max(500.0, xv[0]), bounds.fy_min, bounds.fy_max);
+            xu[1] = std::clamp(avg_u / 2.0, bounds.cx_min, bounds.cx_max);
+            xv[1] = std::clamp(avg_v / 2.0, bounds.cy_min, bounds.cy_max);
+        }
+        CameraMatrix K{xu[0], xv[0], xu[1], xv[1]};
+        return K;
     }
-
-    CameraMatrix K{xu[0], xv[0], xu[1], xv[1]};
-    return K;
 }
 
 // Alternate between fitting distortion coefficients and re-estimating
@@ -90,9 +119,9 @@ std::optional<CameraMatrix> estimate_intrinsics_linear(
 std::optional<LinearInitResult> estimate_intrinsics_linear_iterative(
     const std::vector<Observation<double>>& obs,
     int num_radial,
-    int max_iterations) {
-    // Start with the simple linear estimate that ignores distortion.
-    auto K_opt = estimate_intrinsics_linear(obs);
+    int max_iterations,
+    bool use_skew) {
+    auto K_opt = estimate_intrinsics_linear(obs, std::nullopt, use_skew);
     if (!K_opt) {
         return std::nullopt;
     }
@@ -103,7 +132,7 @@ std::optional<LinearInitResult> estimate_intrinsics_linear_iterative(
 
     for (int iter = 0; iter < max_iterations; ++iter) {
         // Estimate distortion for current intrinsics using original observations.
-        auto dist_opt = fit_distortion(obs, K.fx, K.fy, K.cx, K.cy, num_radial);
+        auto dist_opt = fit_distortion(obs, K.fx, K.fy, K.cx, K.cy, K.skew, num_radial);
         if (!dist_opt) {
             return std::nullopt;
         }
@@ -115,27 +144,27 @@ std::optional<LinearInitResult> estimate_intrinsics_linear_iterative(
             Eigen::Vector2d norm(obs[i].x, obs[i].y);
             Eigen::Vector2d distorted = apply_distortion(norm, dist);
             Eigen::Vector2d delta = distorted - norm;
-            double u_corr = obs[i].u - K.fx * delta.x();
+            double u_corr = obs[i].u - K.fx * delta.x() - K.skew * delta.y();
             double v_corr = obs[i].v - K.fy * delta.y();
             corrected[i] = {obs[i].x, obs[i].y, u_corr, v_corr};
         }
 
-        auto K_new_opt = estimate_intrinsics_linear(corrected);
+        auto K_new_opt = estimate_intrinsics_linear(corrected, std::nullopt, use_skew);
         if (!K_new_opt) {
             break;
         }
         CameraMatrix K_new = *K_new_opt;
 
         double diff = std::abs(K_new.fx - K.fx) + std::abs(K_new.fy - K.fy) +
-                      std::abs(K_new.cx - K.cx) + std::abs(K_new.cy - K.cy);
+                      std::abs(K_new.cx - K.cx) + std::abs(K_new.cy - K.cy) +
+                      std::abs(K_new.skew - K.skew);
         K = K_new;
         if (diff < 1e-6) {
             break;  // Converged
         }
     }
 
-    // Final distortion estimate using refined intrinsics.
-    auto dual_opt = fit_distortion_dual(obs, K.fx, K.fy, K.cx, K.cy, num_radial);
+    auto dual_opt = fit_distortion_dual(obs, K.fx, K.fy, K.cx, K.cy, K.skew, num_radial);
     if (!dual_opt) {
         return std::nullopt;
     }
@@ -164,7 +193,7 @@ struct IntrinsicsVPResidual {
             return Observation<T>{T(obs.x), T(obs.y), T(obs.u), T(obs.v)};
         });
 
-        auto dr = fit_distortion_full(o, intr[0], intr[1], intr[2], intr[3], num_radial_);
+        auto dr = fit_distortion_full(o, intr[0], intr[1], intr[2], intr[3], intr[4], num_radial_);
         if (!dr) return false;
         const auto& r = dr->residuals;
         for (int i = 0; i < r.size(); ++i) residuals[i] = r[i];
@@ -173,8 +202,8 @@ struct IntrinsicsVPResidual {
 
     // Compute optimal distortion coeffs for given intrinsics (useful after
     // Solve).  This is still used by the API after the optimization.
-    Eigen::VectorXd SolveDistortionFor(const double intr[4]) const {
-        auto d = fit_distortion(obs_, intr[0], intr[1], intr[2], intr[3], num_radial_);
+    Eigen::VectorXd SolveDistortionFor(const double intr[5]) const {
+        auto d = fit_distortion(obs_, intr[0], intr[1], intr[2], intr[3], intr[4], num_radial_);
         return d ? d->distortion : Eigen::VectorXd{};
     }
 };
@@ -184,7 +213,8 @@ static bool compute_covariance(
     ceres::CostFunction& cost,
     double const* intrinsics,
     ceres::Problem& problem,
-    IntrinsicOptimizationResult& result
+    IntrinsicOptimizationResult& result,
+    int param_dim
 ) {
     // Recompute residuals and RMSE
     const int m = static_cast<int>(n_obs) * 2;
@@ -196,7 +226,7 @@ static bool compute_covariance(
 
     double ssr = 0.0;
     for (double r : residuals) ssr += r * r;
-    const int dof = m - 4; // 4 nonlinear params in this problem
+    const int dof = m - param_dim;
     result.reprojection_error = std::sqrt(ssr / m);
     const double sigma2 = ssr / std::max(1, dof);
 
@@ -209,11 +239,10 @@ static bool compute_covariance(
         return false;
     }
 
-    double cov4x4[16];
-    cov.GetCovarianceBlock(intrinsics, intrinsics, cov4x4);
+    double cov5x5[25];
+    cov.GetCovarianceBlock(intrinsics, intrinsics, cov5x5);
 
-    // Scale by estimated noise variance (unit weights assumption).
-    Eigen::Map<Eigen::Matrix4d> covar(cov4x4);
+    Eigen::Map<Eigen::Matrix<double,5,5>> covar(cov5x5);
     covar *= sigma2;
     result.covariance = covar;
 
@@ -225,19 +254,21 @@ IntrinsicOptimizationResult optimize_intrinsics(
     int num_radial,
     const CameraMatrix& initial_guess,
     bool verb,
-    std::optional<CalibrationBounds> bounds_opt
+    std::optional<CalibrationBounds> bounds_opt,
+    bool use_skew
 ) {
-    double intrinsics[4] = {
+    double intrinsics[5] = {
         initial_guess.fx,
         initial_guess.fy,
         initial_guess.cx,
-        initial_guess.cy
+        initial_guess.cy,
+        initial_guess.skew
     };
 
     ceres::Problem problem;
     auto* functor = new IntrinsicsVPResidual(obs, num_radial);
     auto* cost = new ceres::AutoDiffCostFunction<IntrinsicsVPResidual,
-                                                 ceres::DYNAMIC, 4>(functor,
+                                                 ceres::DYNAMIC, 5>(functor,
                                                                       static_cast<int>(obs.size()) * 2);
 
     problem.AddResidualBlock(cost, /*loss=*/nullptr, intrinsics);
@@ -247,6 +278,13 @@ IntrinsicOptimizationResult optimize_intrinsics(
     problem.SetParameterLowerBound(intrinsics, 1, bounds.fy_min);
     problem.SetParameterLowerBound(intrinsics, 2, bounds.cx_min);
     problem.SetParameterLowerBound(intrinsics, 3, bounds.cy_min);
+    if (use_skew) {
+        problem.SetParameterLowerBound(intrinsics, 4, bounds.skew_min);
+        problem.SetParameterUpperBound(intrinsics, 4, bounds.skew_max);
+    } else {
+        problem.SetParameterLowerBound(intrinsics, 4, initial_guess.skew);
+        problem.SetParameterUpperBound(intrinsics, 4, initial_guess.skew);
+    }
 
     problem.SetParameterUpperBound(intrinsics, 0, bounds.fx_max);
     problem.SetParameterUpperBound(intrinsics, 1, bounds.fy_max);
@@ -268,16 +306,17 @@ IntrinsicOptimizationResult optimize_intrinsics(
     result.camera.K.fy = intrinsics[1];
     result.camera.K.cx = intrinsics[2];
     result.camera.K.cy = intrinsics[3];
+    result.camera.K.skew = intrinsics[4];
 
     auto dual_opt = fit_distortion_dual(
-        obs, intrinsics[0], intrinsics[1], intrinsics[2], intrinsics[3], num_radial);
+        obs, intrinsics[0], intrinsics[1], intrinsics[2], intrinsics[3], intrinsics[4], num_radial);
     if (dual_opt) {
         result.camera.distortion = dual_opt->distortion;
     }
     result.summary = summary.BriefReport();
 
-    // Compute covariance using the optimized cost function
-    if (!compute_covariance(obs.size(), *cost, intrinsics, problem, result)) {
+    int param_dim = use_skew ? 5 : 4;
+    if (!compute_covariance(obs.size(), *cost, intrinsics, problem, result, param_dim)) {
         std::cerr << "Covariance computation failed.\n";
     }
 

--- a/test/bundle_test.cpp
+++ b/test/bundle_test.cpp
@@ -7,78 +7,152 @@
 using namespace calib;
 
 TEST(OptimizeBundle, RecoversXAndIntrinsics_NoDistortion) {
-    for (double skew : {0.0, 5.0}) {
-        RNG rng(7);
-        // GT
-        Eigen::Affine3d g_T_c_gt = make_pose(
-            Eigen::Vector3d(0.03, 0.00, 0.12),
-            Eigen::Vector3d(0,1,0), deg2rad(8.0)
-        );
-        Eigen::Affine3d b_T_t_gt = make_pose(
-            Eigen::Vector3d(0.5, -0.1, 0.8),
-            Eigen::Vector3d(1,0,0), deg2rad(14.0)
-        );
+    const double skew = 0;
+    RNG rng(7);
+    // GT
+    Eigen::Affine3d g_T_c_gt = make_pose(
+        Eigen::Vector3d(0.03, 0.00, 0.12),
+        Eigen::Vector3d(0,1,0), deg2rad(8.0)
+    );
+    Eigen::Affine3d b_T_t_gt = make_pose(
+        Eigen::Vector3d(0.5, -0.1, 0.8),
+        Eigen::Vector3d(1,0,0), deg2rad(14.0)
+    );
 
-        Camera<BrownConradyd> cam_gt;
-        cam_gt.K.fx = 1000;
-        cam_gt.K.fy = 1005;
-        cam_gt.K.cx = 640;
-        cam_gt.K.cy = 360;
-        cam_gt.K.skew = skew;
-        cam_gt.distortion.coeffs = Eigen::VectorXd::Zero(5);
+    Camera<BrownConradyd> cam_gt;
+    cam_gt.K.fx = 1000;
+    cam_gt.K.fy = 1005;
+    cam_gt.K.cx = 640;
+    cam_gt.K.cy = 360;
+    cam_gt.K.skew = skew;
+    cam_gt.distortion.coeffs = Eigen::VectorXd::Zero(5);
 
-        // Data
-        SimulatedHandEye sim{g_T_c_gt, b_T_t_gt, cam_gt};
-        sim.make_sequence(25, rng);
-        sim.make_target_grid(8, 11, 0.02);
-        sim.render_pixels(0.3, &rng); // 0.3 px noise
-        sim.render_pixels();
+    // Data
+    SimulatedHandEye sim{g_T_c_gt, b_T_t_gt, cam_gt};
+    sim.make_sequence(25, rng);
+    sim.make_target_grid(8, 11, 0.02);
+    sim.render_pixels();  // zero noise
 
-        // Bad initial intrinsics and X
-        Camera<BrownConradyd> cam0;
-        cam0.K.fx = cam_gt.K.fx * 0.97;
-        cam0.K.fy = cam_gt.K.fy * 1.03;
-        cam0.K.cx = cam_gt.K.cx + 5.0;
-        cam0.K.cy = cam_gt.K.cy - 4.0;
-        cam0.K.skew = cam_gt.K.skew + 0.5;
-        cam0.distortion.coeffs = Eigen::VectorXd::Zero(5);
+    // Bad initial intrinsics and X
+    Camera<BrownConradyd> cam0;
+    cam0.K.fx = cam_gt.K.fx * 0.97;
+    cam0.K.fy = cam_gt.K.fy * 1.03;
+    cam0.K.cx = cam_gt.K.cx + 5.0;
+    cam0.K.cy = cam_gt.K.cy - 4.0;
+    cam0.K.skew = cam_gt.K.skew;
+    cam0.distortion.coeffs = Eigen::VectorXd::Zero(5);
 
-        Eigen::Affine3d g_T_c0 = g_T_c_gt;
-        g_T_c0.translation() += Eigen::Vector3d(-0.01, 0.006, -0.004);
-        g_T_c0.linear() = axis_angle_to_R(Eigen::Vector3d(0.3,0.7,-0.2).normalized(), deg2rad(2.0)) * g_T_c0.linear();
+    Eigen::Affine3d g_T_c0 = g_T_c_gt;
+    g_T_c0.translation() += Eigen::Vector3d(-0.01, 0.006, -0.004);
+    g_T_c0.linear() = axis_angle_to_R(Eigen::Vector3d(0.3,0.7,-0.2).normalized(), deg2rad(2.0)) * g_T_c0.linear();
 
-        // Options: refine intrinsics (no distortion)
-        BundleOptions opts;
-        opts.optimize_intrinsics = true;
-        opts.optimize_skew = (skew != 0.0);
-        opts.verbose = false;
+    // Options: refine intrinsics (no distortion)
+    BundleOptions opts;
+    opts.optimize_intrinsics = true;
+    opts.optimize_skew = false;
+    opts.optimizer = OptimizerType::DENSE_QR;
+    opts.huber_delta = -1;  // no regularization
+    opts.verbose = false;
 
-        auto result = optimize_bundle<Camera<BrownConradyd>>(sim.observations, {cam0}, {g_T_c0}, b_T_t_gt, opts);
-        const auto& X = result.g_T_c[0];
-        const auto& Kf = result.cameras[0].K;
-        const auto& b_T_t_est = result.b_T_t;
+    auto result = optimize_bundle<Camera<BrownConradyd>>(sim.observations, {cam0}, {g_T_c0}, b_T_t_gt, opts);
+    const auto& X = result.g_T_c[0];
+    const auto& Kf = result.cameras[0].K;
+    const auto& b_T_t_est = result.b_T_t;
 
-        const auto& K_gt = cam_gt.K;
-        const auto& X_gt = g_T_c_gt;
-        // X close to GT
-        double rot_err = rad2deg(rotation_angle(X.linear().transpose() * X_gt.linear()));
-        double tr_err  = (X.translation() - X_gt.translation()).norm();
-        EXPECT_LT(rot_err, 0.08);
-        EXPECT_LT(tr_err,  0.003);
+    const auto& K_gt = cam_gt.K;
+    const auto& X_gt = g_T_c_gt;
+    // X close to GT
+    double rot_err = rad2deg(rotation_angle(X.linear().transpose() * X_gt.linear()));
+    double tr_err  = (X.translation() - X_gt.translation()).norm();
+    EXPECT_LT(rot_err, 1e-6);
+    EXPECT_LT(tr_err,  1e-6);
 
-        // Intrinsics recovered
-        EXPECT_NEAR(Kf.fx, K_gt.fx, 2.0);
-        EXPECT_NEAR(Kf.fy, K_gt.fy, 2.0);
-        EXPECT_NEAR(Kf.cx, K_gt.cx, 2.0);
-        EXPECT_NEAR(Kf.cy, K_gt.cy, 2.0);
-        EXPECT_NEAR(Kf.skew, K_gt.skew, 2.0);
+    // Intrinsics recovered
+    EXPECT_NEAR(Kf.fx, K_gt.fx, 1e-8);
+    EXPECT_NEAR(Kf.fy, K_gt.fy, 1e-8);
+    EXPECT_NEAR(Kf.cx, K_gt.cx, 1e-8);
+    EXPECT_NEAR(Kf.cy, K_gt.cy, 1e-8);
+    EXPECT_NEAR(Kf.skew, K_gt.skew, 1e-9);
 
-        // Recovered base->target should be close
-        double bt_rot = rad2deg(rotation_angle(b_T_t_est.linear().transpose() * b_T_t_gt.linear()));
-        double bt_tr  = (b_T_t_est.translation() - b_T_t_gt.translation()).norm();
-        EXPECT_LT(bt_rot, 0.10);
-        EXPECT_LT(bt_tr,  0.004);
-    }
+    // Recovered base->target should be close
+    double bt_rot = rad2deg(rotation_angle(b_T_t_est.linear().transpose() * b_T_t_gt.linear()));
+    double bt_tr  = (b_T_t_est.translation() - b_T_t_gt.translation()).norm();
+    EXPECT_LT(bt_rot, 1e-8);
+    EXPECT_LT(bt_tr,  1e-8);
+}
+
+TEST(OptimizeBundle, RecoversXAndIntrinsics_NoDistortionSkew) {
+    constexpr double skew = 0.001;
+    RNG rng(7);
+    // GT
+    Eigen::Affine3d g_T_c_gt = make_pose(
+        Eigen::Vector3d(0.03, 0.00, 0.12),
+        Eigen::Vector3d(0,1,0), deg2rad(8.0)
+    );
+    Eigen::Affine3d b_T_t_gt = make_pose(
+        Eigen::Vector3d(0.5, -0.1, 0.8),
+        Eigen::Vector3d(1,0,0), deg2rad(14.0)
+    );
+
+    Camera<BrownConradyd> cam_gt;
+    cam_gt.K.fx = 1000;
+    cam_gt.K.fy = 1005;
+    cam_gt.K.cx = 640;
+    cam_gt.K.cy = 360;
+    cam_gt.K.skew = skew;
+    cam_gt.distortion.coeffs = Eigen::VectorXd::Zero(5);
+
+    // Data
+    SimulatedHandEye sim{g_T_c_gt, b_T_t_gt, cam_gt};
+    sim.make_sequence(25, rng);
+    sim.make_target_grid(8, 11, 0.02);
+    sim.render_pixels();  // no noise
+
+    // Bad initial intrinsics and X
+    Camera<BrownConradyd> cam0;
+    cam0.K.fx = cam_gt.K.fx * 0.97;
+    cam0.K.fy = cam_gt.K.fy * 1.03;
+    cam0.K.cx = cam_gt.K.cx + 5.0;
+    cam0.K.cy = cam_gt.K.cy - 4.0;
+    cam0.K.skew = 0;
+    cam0.distortion.coeffs = Eigen::VectorXd::Zero(5);
+
+    Eigen::Affine3d g_T_c0 = g_T_c_gt;
+    g_T_c0.translation() += Eigen::Vector3d(-0.01, 0.006, -0.004);
+    g_T_c0.linear() = axis_angle_to_R(Eigen::Vector3d(0.3,0.7,-0.2).normalized(), deg2rad(2.0)) * g_T_c0.linear();
+
+    BundleOptions opts;
+    opts.optimize_intrinsics = true;
+    opts.optimize_skew = true;
+    opts.optimizer = OptimizerType::DENSE_QR;
+    opts.huber_delta = -1;  // no regularization
+    opts.verbose = false;
+
+    auto result = optimize_bundle<Camera<BrownConradyd>>(sim.observations, {cam0}, {g_T_c0}, b_T_t_gt, opts);
+    const auto& X = result.g_T_c[0];
+    const auto& Kf = result.cameras[0].K;
+    const auto& b_T_t_est = result.b_T_t;
+
+    const auto& K_gt = cam_gt.K;
+    const auto& X_gt = g_T_c_gt;
+    // X close to GT
+    double rot_err = rad2deg(rotation_angle(X.linear().transpose() * X_gt.linear()));
+    double tr_err  = (X.translation() - X_gt.translation()).norm();
+    EXPECT_LT(rot_err, 1e-6);
+    EXPECT_LT(tr_err,  1e-6);
+
+    // Intrinsics recovered
+    EXPECT_NEAR(Kf.fx, K_gt.fx, 1e-7);
+    EXPECT_NEAR(Kf.fy, K_gt.fy, 1e-7);
+    EXPECT_NEAR(Kf.cx, K_gt.cx, 1e-7);
+    EXPECT_NEAR(Kf.cy, K_gt.cy, 1e-7);
+    EXPECT_NEAR(Kf.skew, K_gt.skew, 1e-7);
+
+    // Recovered base->target should be close
+    double bt_rot = rad2deg(rotation_angle(b_T_t_est.linear().transpose() * b_T_t_gt.linear()));
+    double bt_tr  = (b_T_t_est.translation() - b_T_t_gt.translation()).norm();
+    EXPECT_LT(bt_rot, 1e-8);
+    EXPECT_LT(bt_tr,  1e-8);
 }
 
 TEST(ReprojectionRefine, DistortionRecoveryOptional) {

--- a/test/bundle_test.cpp
+++ b/test/bundle_test.cpp
@@ -68,17 +68,17 @@ TEST(OptimizeBundle, RecoversXAndIntrinsics_NoDistortion) {
     EXPECT_LT(tr_err,  1e-6);
 
     // Intrinsics recovered
-    EXPECT_NEAR(Kf.fx, K_gt.fx, 1e-8);
-    EXPECT_NEAR(Kf.fy, K_gt.fy, 1e-8);
-    EXPECT_NEAR(Kf.cx, K_gt.cx, 1e-8);
-    EXPECT_NEAR(Kf.cy, K_gt.cy, 1e-8);
+    EXPECT_NEAR(Kf.fx, K_gt.fx, 1e-6);
+    EXPECT_NEAR(Kf.fy, K_gt.fy, 1e-6);
+    EXPECT_NEAR(Kf.cx, K_gt.cx, 1e-6);
+    EXPECT_NEAR(Kf.cy, K_gt.cy, 1e-6);
     EXPECT_NEAR(Kf.skew, K_gt.skew, 1e-9);
 
     // Recovered base->target should be close
     double bt_rot = rad2deg(rotation_angle(b_T_t_est.linear().transpose() * b_T_t_gt.linear()));
     double bt_tr  = (b_T_t_est.translation() - b_T_t_gt.translation()).norm();
-    EXPECT_LT(bt_rot, 1e-8);
-    EXPECT_LT(bt_tr,  1e-8);
+    EXPECT_LT(bt_rot, 1e-6);
+    EXPECT_LT(bt_tr,  1e-6);
 }
 
 TEST(OptimizeBundle, RecoversXAndIntrinsics_NoDistortionSkew) {
@@ -142,17 +142,17 @@ TEST(OptimizeBundle, RecoversXAndIntrinsics_NoDistortionSkew) {
     EXPECT_LT(tr_err,  1e-6);
 
     // Intrinsics recovered
-    EXPECT_NEAR(Kf.fx, K_gt.fx, 1e-7);
-    EXPECT_NEAR(Kf.fy, K_gt.fy, 1e-7);
-    EXPECT_NEAR(Kf.cx, K_gt.cx, 1e-7);
-    EXPECT_NEAR(Kf.cy, K_gt.cy, 1e-7);
-    EXPECT_NEAR(Kf.skew, K_gt.skew, 1e-7);
+    EXPECT_NEAR(Kf.fx, K_gt.fx, 1e-6);
+    EXPECT_NEAR(Kf.fy, K_gt.fy, 1e-6);
+    EXPECT_NEAR(Kf.cx, K_gt.cx, 1e-6);
+    EXPECT_NEAR(Kf.cy, K_gt.cy, 1e-6);
+    EXPECT_NEAR(Kf.skew, K_gt.skew, 1e-6);
 
     // Recovered base->target should be close
     double bt_rot = rad2deg(rotation_angle(b_T_t_est.linear().transpose() * b_T_t_gt.linear()));
     double bt_tr  = (b_T_t_est.translation() - b_T_t_gt.translation()).norm();
-    EXPECT_LT(bt_rot, 1e-8);
-    EXPECT_LT(bt_tr,  1e-8);
+    EXPECT_LT(bt_rot, 1e-6);
+    EXPECT_LT(bt_tr,  1e-6);
 }
 
 TEST(ReprojectionRefine, DistortionRecoveryOptional) {

--- a/test/bundle_test.cpp
+++ b/test/bundle_test.cpp
@@ -7,72 +7,78 @@
 using namespace calib;
 
 TEST(OptimizeBundle, RecoversXAndIntrinsics_NoDistortion) {
-    RNG rng(7);
-    // GT
-    Eigen::Affine3d g_T_c_gt = make_pose(
-        Eigen::Vector3d(0.03, 0.00, 0.12),
-        Eigen::Vector3d(0,1,0), deg2rad(8.0)
-    );
-    Eigen::Affine3d b_T_t_gt = make_pose(
-        Eigen::Vector3d(0.5, -0.1, 0.8),
-        Eigen::Vector3d(1,0,0), deg2rad(14.0)
-    );
+    for (double skew : {0.0, 5.0}) {
+        RNG rng(7);
+        // GT
+        Eigen::Affine3d g_T_c_gt = make_pose(
+            Eigen::Vector3d(0.03, 0.00, 0.12),
+            Eigen::Vector3d(0,1,0), deg2rad(8.0)
+        );
+        Eigen::Affine3d b_T_t_gt = make_pose(
+            Eigen::Vector3d(0.5, -0.1, 0.8),
+            Eigen::Vector3d(1,0,0), deg2rad(14.0)
+        );
 
-    Camera<BrownConradyd> cam_gt;
-    cam_gt.K.fx = 1000;
-    cam_gt.K.fy = 1005;
-    cam_gt.K.cx = 640;
-    cam_gt.K.cy = 360;
-    cam_gt.distortion.coeffs = Eigen::VectorXd::Zero(5);
+        Camera<BrownConradyd> cam_gt;
+        cam_gt.K.fx = 1000;
+        cam_gt.K.fy = 1005;
+        cam_gt.K.cx = 640;
+        cam_gt.K.cy = 360;
+        cam_gt.K.skew = skew;
+        cam_gt.distortion.coeffs = Eigen::VectorXd::Zero(5);
 
-    // Data
-    SimulatedHandEye sim{g_T_c_gt, b_T_t_gt, cam_gt};
-    sim.make_sequence(25, rng);
-    sim.make_target_grid(8, 11, 0.02);
-    sim.render_pixels(0.3, &rng); // 0.3 px noise
-    sim.render_pixels();
+        // Data
+        SimulatedHandEye sim{g_T_c_gt, b_T_t_gt, cam_gt};
+        sim.make_sequence(25, rng);
+        sim.make_target_grid(8, 11, 0.02);
+        sim.render_pixels(0.3, &rng); // 0.3 px noise
+        sim.render_pixels();
 
-    // Bad initial intrinsics and X
-    Camera<BrownConradyd> cam0;
-    cam0.K.fx = cam_gt.K.fx * 0.97;
-    cam0.K.fy = cam_gt.K.fy * 1.03;
-    cam0.K.cx = cam_gt.K.cx + 5.0;
-    cam0.K.cy = cam_gt.K.cy - 4.0;
-    cam0.distortion.coeffs = Eigen::VectorXd::Zero(5);
+        // Bad initial intrinsics and X
+        Camera<BrownConradyd> cam0;
+        cam0.K.fx = cam_gt.K.fx * 0.97;
+        cam0.K.fy = cam_gt.K.fy * 1.03;
+        cam0.K.cx = cam_gt.K.cx + 5.0;
+        cam0.K.cy = cam_gt.K.cy - 4.0;
+        cam0.K.skew = cam_gt.K.skew + 0.5;
+        cam0.distortion.coeffs = Eigen::VectorXd::Zero(5);
 
-    Eigen::Affine3d g_T_c0 = g_T_c_gt;
-    g_T_c0.translation() += Eigen::Vector3d(-0.01, 0.006, -0.004);
-    g_T_c0.linear() = axis_angle_to_R(Eigen::Vector3d(0.3,0.7,-0.2).normalized(), deg2rad(2.0)) * g_T_c0.linear();
+        Eigen::Affine3d g_T_c0 = g_T_c_gt;
+        g_T_c0.translation() += Eigen::Vector3d(-0.01, 0.006, -0.004);
+        g_T_c0.linear() = axis_angle_to_R(Eigen::Vector3d(0.3,0.7,-0.2).normalized(), deg2rad(2.0)) * g_T_c0.linear();
 
-    // Options: refine intrinsics (no distortion)
-    BundleOptions opts;
-    opts.optimize_intrinsics = true;
-    opts.verbose = false;
+        // Options: refine intrinsics (no distortion)
+        BundleOptions opts;
+        opts.optimize_intrinsics = true;
+        opts.optimize_skew = (skew != 0.0);
+        opts.verbose = false;
 
-    auto result = optimize_bundle<Camera<BrownConradyd>>(sim.observations, {cam0}, {g_T_c0}, b_T_t_gt, opts);
-    const auto& X = result.g_T_c[0];
-    const auto& Kf = result.cameras[0].K;
-    const auto& b_T_t_est = result.b_T_t;
+        auto result = optimize_bundle<Camera<BrownConradyd>>(sim.observations, {cam0}, {g_T_c0}, b_T_t_gt, opts);
+        const auto& X = result.g_T_c[0];
+        const auto& Kf = result.cameras[0].K;
+        const auto& b_T_t_est = result.b_T_t;
 
-    const auto& K_gt = cam_gt.K;
-    const auto& X_gt = g_T_c_gt;
-    // X close to GT
-    double rot_err = rad2deg(rotation_angle(X.linear().transpose() * X_gt.linear()));
-    double tr_err  = (X.translation() - X_gt.translation()).norm();
-    EXPECT_LT(rot_err, 0.08);
-    EXPECT_LT(tr_err,  0.003);
+        const auto& K_gt = cam_gt.K;
+        const auto& X_gt = g_T_c_gt;
+        // X close to GT
+        double rot_err = rad2deg(rotation_angle(X.linear().transpose() * X_gt.linear()));
+        double tr_err  = (X.translation() - X_gt.translation()).norm();
+        EXPECT_LT(rot_err, 0.08);
+        EXPECT_LT(tr_err,  0.003);
 
-    // Intrinsics recovered
-    EXPECT_NEAR(Kf.fx, K_gt.fx, 2.0);
-    EXPECT_NEAR(Kf.fy, K_gt.fy, 2.0);
-    EXPECT_NEAR(Kf.cx, K_gt.cx, 2.0);
-    EXPECT_NEAR(Kf.cy, K_gt.cy, 2.0);
+        // Intrinsics recovered
+        EXPECT_NEAR(Kf.fx, K_gt.fx, 2.0);
+        EXPECT_NEAR(Kf.fy, K_gt.fy, 2.0);
+        EXPECT_NEAR(Kf.cx, K_gt.cx, 2.0);
+        EXPECT_NEAR(Kf.cy, K_gt.cy, 2.0);
+        EXPECT_NEAR(Kf.skew, K_gt.skew, 2.0);
 
-    // Recovered base->target should be close
-    double bt_rot = rad2deg(rotation_angle(b_T_t_est.linear().transpose() * b_T_t_gt.linear()));
-    double bt_tr  = (b_T_t_est.translation() - b_T_t_gt.translation()).norm();
-    EXPECT_LT(bt_rot, 0.10);
-    EXPECT_LT(bt_tr,  0.004);
+        // Recovered base->target should be close
+        double bt_rot = rad2deg(rotation_angle(b_T_t_est.linear().transpose() * b_T_t_gt.linear()));
+        double bt_tr  = (b_T_t_est.translation() - b_T_t_gt.translation()).norm();
+        EXPECT_LT(bt_rot, 0.10);
+        EXPECT_LT(bt_tr,  0.004);
+    }
 }
 
 TEST(ReprojectionRefine, DistortionRecoveryOptional) {

--- a/test/calib_test.cpp
+++ b/test/calib_test.cpp
@@ -42,16 +42,12 @@ TEST(CameraCalibrationTest, PlanarViewsExact) {
 
     // Generate several poses
     std::vector<PlanarView> views(4);
-    std::vector<Eigen::Affine3d> poses_true(4);
-    poses_true[0] = Eigen::Affine3d::Identity();
+    std::vector<Eigen::Affine3d> poses_true(4, Eigen::Affine3d::Identity());
     poses_true[0].translation() = Eigen::Vector3d(0.1, -0.1, 2.0);
-    poses_true[1] = Eigen::Affine3d::Identity();
     poses_true[1].linear() = Eigen::AngleAxisd(0.2, Eigen::Vector3d::UnitY()).toRotationMatrix();
     poses_true[1].translation() = Eigen::Vector3d(-0.2, 0.1, 1.8);
-    poses_true[2] = Eigen::Affine3d::Identity();
     poses_true[2].linear() = Eigen::AngleAxisd(-0.15, Eigen::Vector3d::UnitX()).toRotationMatrix();
     poses_true[2].translation() = Eigen::Vector3d(0.05, 0.2, 2.2);
-    poses_true[3] = Eigen::Affine3d::Identity();
     poses_true[3].linear() = Eigen::AngleAxisd(0.1, Eigen::Vector3d::UnitZ()).toRotationMatrix();
     poses_true[3].translation() = Eigen::Vector3d(-0.1, -0.15, 1.9);
 

--- a/test/distortion_test.cpp
+++ b/test/distortion_test.cpp
@@ -76,7 +76,7 @@ TEST(DistortionTest, ExactFit) {
         k_true, p1_true, p2_true, fx, fy, cx, cy, 500, 0.0);
 
     // Fit distortion parameters
-    auto distortion_opt = fit_distortion(observations, fx, fy, cx, cy, 2);
+    auto distortion_opt = fit_distortion(observations, fx, fy, cx, cy, 0.0, 2);
     ASSERT_TRUE(distortion_opt.has_value());
     Eigen::VectorXd distortion = distortion_opt->distortion;
 
@@ -100,7 +100,7 @@ TEST(DistortionTest, NoisyFit) {
         k_true, p1_true, p2_true, fx, fy, cx, cy, 1000, 0.5);
 
     // Fit distortion parameters
-    auto distortion_opt = fit_distortion(observations, fx, fy, cx, cy, 2);
+    auto distortion_opt = fit_distortion(observations, fx, fy, cx, cy, 0.0, 2);
     ASSERT_TRUE(distortion_opt.has_value());
     Eigen::VectorXd distortion = distortion_opt->distortion;
 
@@ -119,7 +119,7 @@ TEST(DistortionTest, DualModel) {
     auto observations = generate_synthetic_data(
         k_true, p1_true, p2_true, fx, fy, cx, cy, 200, 0.0);
 
-    auto dual_opt = fit_distortion_dual(observations, fx, fy, cx, cy, 2);
+    auto dual_opt = fit_distortion_dual(observations, fx, fy, cx, cy, 0.0, 2);
     ASSERT_TRUE(dual_opt.has_value());
     const auto& model = dual_opt->distortion;
 

--- a/test/intrinsics_test.cpp
+++ b/test/intrinsics_test.cpp
@@ -34,7 +34,7 @@ static void distort_and_project(double x, double y,
     double y_t = y * radial + p1 * (r2 + 2.0 * y * y) + 2.0 * p2 * x * y;
 
     // Project to pixel coords
-    u = intr.fx * x_t + intr.cx;
+    u = intr.fx * x_t + intr.skew * y_t + intr.cx;
     v = intr.fy * y_t + intr.cy;
 }
 
@@ -90,7 +90,7 @@ struct IntrinsicsVPResidualTestFunctor {
                                   static_cast<T>(obs.u), static_cast<T>(obs.v)};
         });
         auto dr = fit_distortion_full(
-            o, intr[0], intr[1], intr[2], intr[3], num_radial);
+            o, intr[0], intr[1], intr[2], intr[3], intr[4], num_radial);
         if (!dr) {
             return false;
         }
@@ -103,182 +103,160 @@ struct IntrinsicsVPResidualTestFunctor {
 // Verify that the linear intrinsics estimation provides a reasonable
 // initial guess even in the presence of moderate distortion and noise.
 TEST(IntrinsicsTest, LinearInitialGuess) {
-    CameraMatrix intr_true{800.0, 820.0, 640.0, 360.0};
     std::vector<double> k_radial = {-0.20, 0.03};
     double p1 = 0.001, p2 = -0.0005;
-
-    auto observations = generate_synthetic_data(
-        intr_true, k_radial, p1, p2, 300, 0.2);
-
-    auto guess_opt = estimate_intrinsics_linear(observations);
-    ASSERT_TRUE(guess_opt.has_value());
-    CameraMatrix guess = *guess_opt;
-
-    EXPECT_NEAR(guess.fx, intr_true.fx, 60.0);
-    EXPECT_NEAR(guess.fy, intr_true.fy, 60.0);
-    EXPECT_NEAR(guess.cx, intr_true.cx, 25.0);
-    EXPECT_NEAR(guess.cy, intr_true.cy, 25.0);
+    for (double skew : {0.0, 5.0}) {
+        CameraMatrix intr_true{800.0, 820.0, 640.0, 360.0, skew};
+        auto observations = generate_synthetic_data(
+            intr_true, k_radial, p1, p2, 300, 0.2);
+        auto guess_opt = estimate_intrinsics_linear(observations, std::nullopt, skew != 0.0);
+        ASSERT_TRUE(guess_opt.has_value());
+        CameraMatrix guess = *guess_opt;
+        EXPECT_NEAR(guess.fx, intr_true.fx, 60.0);
+        EXPECT_NEAR(guess.fy, intr_true.fy, 60.0);
+        EXPECT_NEAR(guess.cx, intr_true.cx, 25.0);
+        EXPECT_NEAR(guess.cy, intr_true.cy, 25.0);
+        EXPECT_NEAR(guess.skew, intr_true.skew, 60.0);
+    }
 }
 
 // Verify that alternating linear estimation of intrinsics and distortion
 // yields a better initialization than a single linear solve.
 TEST(IntrinsicsTest, IterativeLinearInitialization) {
-    CameraMatrix intr_true{800.0, 820.0, 640.0, 360.0};
     std::vector<double> k_radial = {-0.20, 0.03};
     double p1 = 0.001, p2 = -0.0005;
+    for (double skew : {0.0, 5.0}) {
+        CameraMatrix intr_true{800.0, 820.0, 640.0, 360.0, skew};
+        auto observations = generate_synthetic_data(
+            intr_true, k_radial, p1, p2, 300, 0.2);
 
-    auto observations = generate_synthetic_data(
-        intr_true, k_radial, p1, p2, 300, 0.2);
+        auto simple_guess = estimate_intrinsics_linear(observations, std::nullopt, skew != 0.0);
+        ASSERT_TRUE(simple_guess.has_value());
 
-    auto simple_guess = estimate_intrinsics_linear(observations);
-    ASSERT_TRUE(simple_guess.has_value());
+        auto refined_opt = estimate_intrinsics_linear_iterative(observations, 2, 5, skew != 0.0);
+        ASSERT_TRUE(refined_opt.has_value());
 
-    auto refined_opt = estimate_intrinsics_linear_iterative(observations, 2, 5);
-    ASSERT_TRUE(refined_opt.has_value());
+        auto refined = refined_opt->camera.K;
+        auto simple = *simple_guess;
 
-    auto refined = refined_opt->camera.K;
-    auto simple = *simple_guess;
+        double err_simple = std::abs(simple.fx - intr_true.fx) +
+                            std::abs(simple.fy - intr_true.fy) +
+                            std::abs(simple.cx - intr_true.cx) +
+                            std::abs(simple.cy - intr_true.cy) +
+                            std::abs(simple.skew - intr_true.skew);
 
-    double err_simple = std::abs(simple.fx - intr_true.fx) +
-                        std::abs(simple.fy - intr_true.fy) +
-                        std::abs(simple.cx - intr_true.cx) +
-                        std::abs(simple.cy - intr_true.cy);
+        double err_refined = std::abs(refined.fx - intr_true.fx) +
+                             std::abs(refined.fy - intr_true.fy) +
+                             std::abs(refined.cx - intr_true.cx) +
+                             std::abs(refined.cy - intr_true.cy) +
+                             std::abs(refined.skew - intr_true.skew);
 
-    double err_refined = std::abs(refined.fx - intr_true.fx) +
-                         std::abs(refined.fy - intr_true.fy) +
-                         std::abs(refined.cx - intr_true.cx) +
-                         std::abs(refined.cy - intr_true.cy);
+        EXPECT_LT(err_refined, err_simple);
 
-    EXPECT_LT(err_refined, err_simple);
-
-    // Distortion parameters should also be close to the ground truth
-    ASSERT_EQ(refined_opt->camera.distortion.forward.size(), 4);
-    EXPECT_NEAR(refined_opt->camera.distortion.forward[0], k_radial[0], 0.5);
-    EXPECT_NEAR(refined_opt->camera.distortion.forward[1], k_radial[1], 0.5);
-    EXPECT_NEAR(refined_opt->camera.distortion.forward[2], p1, 0.001);
-    EXPECT_NEAR(refined_opt->camera.distortion.forward[3], p2, 0.001);
+        ASSERT_EQ(refined_opt->camera.distortion.forward.size(), 4);
+        EXPECT_NEAR(refined_opt->camera.distortion.forward[0], k_radial[0], 0.5);
+        EXPECT_NEAR(refined_opt->camera.distortion.forward[1], k_radial[1], 0.5);
+        EXPECT_NEAR(refined_opt->camera.distortion.forward[2], p1, 0.001);
+        EXPECT_NEAR(refined_opt->camera.distortion.forward[3], p2, 0.001);
+    }
 }
 
 TEST(IntrinsicsTest, OptimizeExact) {
-    // True intrinsics
-    CameraMatrix intr_true{800.0, 820.0, 640.0, 360.0};
-
-    // True distortion
     std::vector<double> k_radial = {-0.20, 0.03};
     double p1 = 0.001, p2 = -0.0005;
+    for (double skew : {0.0, 5.0}) {
+        CameraMatrix intr_true{800.0, 820.0, 640.0, 360.0, skew};
 
-    // Generate perfect synthetic data
-    auto observations = generate_synthetic_data(
-        intr_true, k_radial, p1, p2, 300, 0.0);
+        auto observations = generate_synthetic_data(
+            intr_true, k_radial, p1, p2, 300, 0.0);
 
-    // Initial guess (slightly off)
-    auto initial_guess = estimate_intrinsics_linear_iterative(observations, 2, 5);
-    ASSERT_TRUE(initial_guess.has_value());
+        auto initial_guess = estimate_intrinsics_linear_iterative(observations, 2, 5, skew != 0.0);
+        ASSERT_TRUE(initial_guess.has_value());
 
-    // Optimize
-    auto result = optimize_intrinsics(observations, 2, initial_guess->camera.K, false);
+        auto result = optimize_intrinsics(observations, 2, initial_guess->camera.K, false, std::nullopt, skew != 0.0);
 
-    // Check results
-    EXPECT_NEAR(result.camera.K.fx, intr_true.fx, 1e-6);
-    EXPECT_NEAR(result.camera.K.fy, intr_true.fy, 1e-6);
-    EXPECT_NEAR(result.camera.K.cx, intr_true.cx, 1e-6);
-    EXPECT_NEAR(result.camera.K.cy, intr_true.cy, 1e-6);
+        EXPECT_NEAR(result.camera.K.fx, intr_true.fx, 1e-6);
+        EXPECT_NEAR(result.camera.K.fy, intr_true.fy, 1e-6);
+        EXPECT_NEAR(result.camera.K.cx, intr_true.cx, 1e-6);
+        EXPECT_NEAR(result.camera.K.cy, intr_true.cy, 1e-6);
+        EXPECT_NEAR(result.camera.K.skew, intr_true.skew, 1e-6);
 
-    EXPECT_NEAR(result.camera.distortion.forward[0], k_radial[0], 1e-6);
-    EXPECT_NEAR(result.camera.distortion.forward[1], k_radial[1], 1e-6);
-    EXPECT_NEAR(result.camera.distortion.forward[2], p1, 1e-6);
-    EXPECT_NEAR(result.camera.distortion.forward[3], p2, 1e-6);
+        EXPECT_NEAR(result.camera.distortion.forward[0], k_radial[0], 1e-6);
+        EXPECT_NEAR(result.camera.distortion.forward[1], k_radial[1], 1e-6);
+        EXPECT_NEAR(result.camera.distortion.forward[2], p1, 1e-6);
+        EXPECT_NEAR(result.camera.distortion.forward[3], p2, 1e-6);
+    }
 }
 
 TEST(IntrinsicsTest, OptimizeNoisy) {
-    // True intrinsics
-    CameraMatrix intr_true{800.0, 820.0, 640.0, 360.0};
-
-    // True distortion
     std::vector<double> k_radial = {-0.20, 0.03};
     double p1 = 0.001, p2 = -0.0005;
+    for (double skew : {0.0, 5.0}) {
+        CameraMatrix intr_true{800.0, 820.0, 640.0, 360.0, skew};
 
-    // Generate synthetic data with noise
-    auto observations = generate_synthetic_data(
-        intr_true, k_radial, p1, p2, 500, 0.5);
+        auto observations = generate_synthetic_data(
+            intr_true, k_radial, p1, p2, 500, 0.5);
 
-    // Obtain an initial guess from the linear estimator
-    auto initial_guess = estimate_intrinsics_linear(observations);
-    ASSERT_TRUE(initial_guess.has_value());
+        auto initial_guess = estimate_intrinsics_linear(observations, std::nullopt, skew != 0.0);
+        ASSERT_TRUE(initial_guess.has_value());
 
-    // Optimize
-    auto result = optimize_intrinsics(observations, 2, *initial_guess, false);
+        auto result = optimize_intrinsics(observations, 2, *initial_guess, false, std::nullopt, skew != 0.0);
 
-    // Check results (with tolerance for noise)
-    EXPECT_NEAR(result.camera.K.fx, intr_true.fx, 10.0);
-    EXPECT_NEAR(result.camera.K.fy, intr_true.fy, 10.0);
-    EXPECT_NEAR(result.camera.K.cx, intr_true.cx, 5.0);
-    EXPECT_NEAR(result.camera.K.cy, intr_true.cy, 5.0);
+        EXPECT_NEAR(result.camera.K.fx, intr_true.fx, 10.0);
+        EXPECT_NEAR(result.camera.K.fy, intr_true.fy, 10.0);
+        EXPECT_NEAR(result.camera.K.cx, intr_true.cx, 5.0);
+        EXPECT_NEAR(result.camera.K.cy, intr_true.cy, 5.0);
+        EXPECT_NEAR(result.camera.K.skew, intr_true.skew, 10.0);
 
-    EXPECT_NEAR(result.camera.distortion.forward[0], k_radial[0], 0.05);
-    EXPECT_NEAR(result.camera.distortion.forward[1], k_radial[1], 0.05);
-    EXPECT_NEAR(result.camera.distortion.forward[2], p1, 0.001);
-    EXPECT_NEAR(result.camera.distortion.forward[3], p2, 0.001);
+        EXPECT_NEAR(result.camera.distortion.forward[0], k_radial[0], 0.05);
+        EXPECT_NEAR(result.camera.distortion.forward[1], k_radial[1], 0.05);
+        EXPECT_NEAR(result.camera.distortion.forward[2], p1, 0.001);
+        EXPECT_NEAR(result.camera.distortion.forward[3], p2, 0.001);
 
-    // Check covariance matrix is valid (positive definite)
-    Eigen::SelfAdjointEigenSolver<Eigen::Matrix4d> eigensolver(result.covariance);
-    EXPECT_GT(eigensolver.eigenvalues().minCoeff(), 0.0);
+        Eigen::SelfAdjointEigenSolver<Eigen::Matrix<double,5,5>> eigensolver(result.covariance);
+        EXPECT_GT(eigensolver.eigenvalues().minCoeff(), 0.0);
+    }
 }
 
 TEST(IntrinsicsTest, DifferentRadialCoeffs) {
-    // Test with different numbers of radial coefficients
-    CameraMatrix intr_true{800.0, 820.0, 640.0, 360.0};
-
-    // True distortion with 3 radial terms
     std::vector<double> k_radial = {-0.20, 0.03, 0.01};
     double p1 = 0.001, p2 = -0.0005;
+    for (double skew : {0.0, 5.0}) {
+        CameraMatrix intr_true{800.0, 820.0, 640.0, 360.0, skew};
+        auto observations = generate_synthetic_data(
+            intr_true, k_radial, p1, p2, 300, 0.1);
 
-    // Generate synthetic data
-    auto observations = generate_synthetic_data(
-        intr_true, k_radial, p1, p2, 300, 0.1);
+        CameraMatrix initial_guess{780.0, 800.0, 630.0, 350.0, skew};
 
-    // Initial guess
-    CameraMatrix initial_guess{780.0, 800.0, 630.0, 350.0};
+        auto result1 = optimize_intrinsics(observations, 1, initial_guess, false, std::nullopt, skew != 0.0);
+        auto result2 = optimize_intrinsics(observations, 2, initial_guess, false, std::nullopt, skew != 0.0);
+        auto result3 = optimize_intrinsics(observations, 3, initial_guess, false, std::nullopt, skew != 0.0);
 
-    // Optimize with 1, 2, and 3 radial coefficients
-    auto result1 = optimize_intrinsics(observations, 1, initial_guess, false);
-    auto result2 = optimize_intrinsics(observations, 2, initial_guess, false);
-    auto result3 = optimize_intrinsics(observations, 3, initial_guess, false);
+        EXPECT_EQ(result1.camera.distortion.forward.size(), 3);
+        EXPECT_EQ(result2.camera.distortion.forward.size(), 4);
+        EXPECT_EQ(result3.camera.distortion.forward.size(), 5);
 
-    // Check that results improve with more coefficients
-    EXPECT_EQ(result1.camera.distortion.forward.size(), 3);  // 1 radial + 2 tangential
-    EXPECT_EQ(result2.camera.distortion.forward.size(), 4);  // 2 radial + 2 tangential
-    EXPECT_EQ(result3.camera.distortion.forward.size(), 5);  // 3 radial + 2 tangential
-
-    // The third model should be closest to the true values
-    EXPECT_NEAR(result3.camera.distortion.forward[0], k_radial[0], 0.05);
-    EXPECT_NEAR(result3.camera.distortion.forward[1], k_radial[1], 0.05);
-    EXPECT_NEAR(result3.camera.distortion.forward[2], k_radial[2], 0.05);
+        EXPECT_NEAR(result3.camera.distortion.forward[0], k_radial[0], 0.05);
+        EXPECT_NEAR(result3.camera.distortion.forward[1], k_radial[1], 0.05);
+        EXPECT_NEAR(result3.camera.distortion.forward[2], k_radial[2], 0.05);
+    }
 }
 
 TEST(IntrinsicsTest, OptimizationSummary) {
-    // True intrinsics
-    CameraMatrix intr_true{800.0, 820.0, 640.0, 360.0};
-
-    // True distortion
     std::vector<double> k_radial = {-0.20, 0.03};
     double p1 = 0.001, p2 = -0.0005;
+    for (double skew : {0.0, 5.0}) {
+        CameraMatrix intr_true{800.0, 820.0, 640.0, 360.0, skew};
+        auto observations = generate_synthetic_data(
+            intr_true, k_radial, p1, p2, 100, 0.1);
 
-    // Generate synthetic data
-    auto observations = generate_synthetic_data(
-        intr_true, k_radial, p1, p2, 100, 0.1);
+        CameraMatrix initial_guess{780.0, 800.0, 630.0, 350.0, skew};
 
-    // Initial guess
-    CameraMatrix initial_guess{780.0, 800.0, 630.0, 350.0};
+        auto result = optimize_intrinsics(observations, 2, initial_guess, true, std::nullopt, skew != 0.0);
 
-    // Optimize with verbose output
-    auto result = optimize_intrinsics(observations, 2, initial_guess, true);
-
-    // Check that the summary is not empty
-    EXPECT_FALSE(result.summary.empty());
-
-    // Should contain success or convergence information
-    EXPECT_TRUE(result.summary.find("Iterations") != std::string::npos &&
-                result.summary.find("Final cost") != std::string::npos &&
-                result.summary.find("CONVERGENCE") != std::string::npos);
+        EXPECT_FALSE(result.summary.empty());
+        EXPECT_TRUE(result.summary.find("Iterations") != std::string::npos &&
+                    result.summary.find("Final cost") != std::string::npos &&
+                    result.summary.find("CONVERGENCE") != std::string::npos);
+    }
 }

--- a/test/intrinsics_test.cpp
+++ b/test/intrinsics_test.cpp
@@ -195,7 +195,7 @@ TEST(IntrinsicsTest, OptimizeExactSkew) {
 
     auto observations = generate_synthetic_data(intr_true, k_radial, p1, p2, 300, 0.0);
 
-    bool use_skew = false;
+    bool use_skew = true;
     auto initial_guess = estimate_intrinsics_linear_iterative(observations, 2, 5, use_skew);
     ASSERT_TRUE(initial_guess.has_value());
 

--- a/test/json_test.cpp
+++ b/test/json_test.cpp
@@ -9,7 +9,7 @@
 using namespace calib;
 
 TEST(JsonReflection, CameraMatrixRoundTrip) {
-    CameraMatrix cam{100.0, 110.0, 10.0, 20.0};
+    CameraMatrix cam{100.0, 110.0, 10.0, 20.0, 1.5};
 
     nlohmann::json j = cam;
     CameraMatrix parsed = j.get<CameraMatrix>();
@@ -18,6 +18,7 @@ TEST(JsonReflection, CameraMatrixRoundTrip) {
     EXPECT_DOUBLE_EQ(parsed.fy, cam.fy);
     EXPECT_DOUBLE_EQ(parsed.cx, cam.cx);
     EXPECT_DOUBLE_EQ(parsed.cy, cam.cy);
+    EXPECT_DOUBLE_EQ(parsed.skew, cam.skew);
 }
 
 TEST(JsonSerialization, ObservationRoundTrip) {
@@ -32,8 +33,8 @@ TEST(JsonSerialization, ObservationRoundTrip) {
 
 TEST(JsonSerialization, IntrinsicResultRoundTrip) {
     IntrinsicOptimizationResult res;
-    res.camera.K = CameraMatrix{100,100,0,0};
-    res.covariance = Eigen::Matrix4d::Identity();
+    res.camera.K = CameraMatrix{100,100,0,0,0};
+    res.covariance = Eigen::Matrix<double,5,5>::Identity();
     res.reprojection_error = 0.5;
     res.summary = "ok";
     nlohmann::json j = res;


### PR DESCRIPTION
## Summary
- incorporate skew parameter into camera matrix and normalization
- refactor intrinsics estimation, joint calibration, and bundle adjustment to handle optional skew
- extend tests to exercise calibration with and without skew and update JSON serialization

## Testing
- `cmake -S . -B build` *(fails: Could not find Ceres package)*

------
https://chatgpt.com/codex/tasks/task_e_68b45e2eadc48332a660148fbb94a1ca