### PR TITLE
Implement planar intrinsics estimation via Zhang method

### DIFF
--- a/include/calib/intrinsics.h
+++ b/include/calib/intrinsics.h
@@ -15,10 +15,12 @@
 
 // std
 #include <optional>
+#include <vector>
 
 // eigen
 #include <Eigen/Core>
 #include <Eigen/Dense>
+#include <Eigen/Geometry>
 
 #include "calib/cameramodel.h"
 #include "calib/optimize.h"
@@ -69,6 +71,21 @@ struct IntrinsicsOptions final : public OptimOptions {
     std::optional<CalibrationBounds> bounds = std::nullopt;  ///< Parameter bounds
 };
 
+struct ImageSize final {
+    int width = 0;
+    int height = 0;
+};
+
+struct CalibrateIntrinsicsOptions {
+    int num_radial = 2;  ///< Number of radial distortion coefficients to estimate
+    bool recenter = true;  ///< Re-center pixels about the image center
+};
+
+struct IntrinsicsResult {
+    PinholeCamera<BrownConradyd> camera;            ///< Estimated camera model
+    std::vector<Eigen::Isometry3d> c_se3_t;         ///< Pose of each view (camera -> target)
+};
+
 template <camera_model CameraT>
 struct IntrinsicsOptimizationResult final : public OptimResult {
     CameraT camera;                          ///< Estimated camera parameters
@@ -86,5 +103,10 @@ auto optimize_intrinsics(const std::vector<PlanarView>& views, const CameraT& in
                          std::vector<Eigen::Isometry3d> init_c_se3_t,
                          const IntrinsicsOptions& opts = {})
     -> IntrinsicsOptimizationResult<CameraT>;
+
+auto extimate_intrinsics_from_planar(const std::vector<PlanarView>& views,
+                                     const ImageSize& image_size,
+                                     const CalibrateIntrinsicsOptions& opts = {})
+    -> IntrinsicsResult;
 
 }  // namespace calib

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -1,8 +1,12 @@
 #include "calib/intrinsics.h"
 
 #include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <stdexcept>
 
 #include "calib/distortion.h"
+#include "calib/homography.h"
 #include "calib/scheimpflug.h"
 #include "ceresutils.h"
 #include "observationutils.h"
@@ -125,5 +129,168 @@ template IntrinsicsOptimizationResult<ScheimpflugCamera<PinholeCamera<BrownConra
 optimize_intrinsics(const std::vector<PlanarView>& views,
                     const ScheimpflugCamera<PinholeCamera<BrownConradyd>>& init_camera,
                     std::vector<Eigen::Isometry3d> init_c_se3_t, const IntrinsicsOptions& opts);
+
+static bool view_has_noncollinear(const PlanarView& view) {
+    if (view.size() < 3) {
+        return false;
+    }
+    for (size_t i = 0; i < view.size() - 2; ++i) {
+        for (size_t j = i + 1; j < view.size() - 1; ++j) {
+            for (size_t k = j + 1; k < view.size(); ++k) {
+                const Eigen::Vector2d a = view[j].object_xy - view[i].object_xy;
+                const Eigen::Vector2d b = view[k].object_xy - view[i].object_xy;
+                if (std::abs(a.x() * b.y() - a.y() * b.x()) > 1e-9) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+static Eigen::Matrix<double, 6, 1> v_ij(const Eigen::Matrix3d& H, int i, int j) {
+    Eigen::Matrix<double, 6, 1> v;
+    v << H(0, i) * H(0, j), H(0, i) * H(1, j) + H(1, i) * H(0, j), H(1, i) * H(1, j),
+        H(2, i) * H(0, j) + H(0, i) * H(2, j), H(2, i) * H(1, j) + H(1, i) * H(2, j),
+        H(2, i) * H(2, j);
+    return v;
+}
+
+IntrinsicsResult extimate_intrinsics_from_planar(const std::vector<PlanarView>& views,
+                                                 const ImageSize& image_size,
+                                                 const CalibrateIntrinsicsOptions& opts) {
+    if (views.empty()) {
+        throw std::invalid_argument("No calibration views provided");
+    }
+
+    const double cx0 = static_cast<double>(image_size.width) / 2.0;
+    const double cy0 = static_cast<double>(image_size.height) / 2.0;
+
+    std::vector<PlanarView> centered = views;
+    for (auto& v : centered) {
+        if (v.size() < 6) {
+            throw std::invalid_argument("Each view must contain at least 6 points");
+        }
+        if (!view_has_noncollinear(v)) {
+            throw std::invalid_argument("Planar correspondences must be non-collinear");
+        }
+        if (opts.recenter) {
+            for (auto& ob : v) {
+                ob.image_uv.x() -= cx0;
+                ob.image_uv.y() -= cy0;
+            }
+        }
+    }
+
+    // Step 2: per-view homographies
+    std::vector<Eigen::Matrix3d> homographies;
+    homographies.reserve(centered.size());
+    for (const auto& view : centered) {
+        std::vector<Eigen::Vector2d> obj(view.size());
+        std::vector<Eigen::Vector2d> img(view.size());
+        for (size_t i = 0; i < view.size(); ++i) {
+            obj[i] = view[i].object_xy;
+            img[i] = view[i].image_uv;
+        }
+        homographies.push_back(estimate_homography_dlt(obj, img));
+    }
+
+    // Step 3: Zhang initialization for K
+    Eigen::MatrixXd V(2 * homographies.size(), 6);
+    for (size_t i = 0; i < homographies.size(); ++i) {
+        const Eigen::Matrix3d& H = homographies[i];
+        V.row(2 * i) = v_ij(H, 0, 1).transpose();
+        V.row(2 * i + 1) = (v_ij(H, 0, 0) - v_ij(H, 1, 1)).transpose();
+    }
+    Eigen::JacobiSVD<Eigen::MatrixXd> svd(V, Eigen::ComputeFullV);
+    Eigen::VectorXd b = svd.matrixV().col(5);
+
+    double B11 = b[0];
+    double B12 = b[1];
+    double B22 = b[2];
+    double B13 = b[3];
+    double B23 = b[4];
+    double B33 = b[5];
+    double v0 = (B12 * B13 - B11 * B23) / (B11 * B22 - B12 * B12);
+    double lambda = B33 - (B13 * B13 + v0 * (B12 * B13 - B11 * B23)) / B11;
+    double alpha = std::sqrt(lambda / B11);
+    double beta = std::sqrt(lambda * B11 / (B11 * B22 - B12 * B12));
+    double gamma = -B12 * alpha * alpha * beta / lambda;
+    double u0 = gamma * v0 / beta - B13 * alpha * alpha / lambda;
+
+    CameraMatrix kmtx{alpha, beta, u0, v0, gamma};
+    if (opts.recenter) {
+        kmtx.cx += cx0;
+        kmtx.cy += cy0;
+    }
+
+    // Step 4: Extrinsics per view
+    Eigen::Matrix3d K;
+    K << kmtx.fx, kmtx.skew, kmtx.cx, 0.0, kmtx.fy, kmtx.cy, 0.0, 0.0, 1.0;
+    Eigen::Matrix3d Kinv = K.inverse();
+    IntrinsicsResult result;
+    for (const auto& H : homographies) {
+        Eigen::Matrix3d Hc = H;
+        Eigen::Vector3d h1 = Hc.col(0);
+        Eigen::Vector3d h2 = Hc.col(1);
+        Eigen::Vector3d h3 = Hc.col(2);
+        Eigen::Vector3d r1 = Kinv * h1;
+        Eigen::Vector3d r2 = Kinv * h2;
+        double s = 1.0 / r1.norm();
+        r1 *= s;
+        r2 *= s;
+        Eigen::Vector3d r3 = r1.cross(r2);
+        Eigen::Matrix3d R;
+        R.col(0) = r1;
+        R.col(1) = r2;
+        R.col(2) = r3;
+        Eigen::JacobiSVD<Eigen::Matrix3d> rsvd(R, Eigen::ComputeFullU | Eigen::ComputeFullV);
+        R = rsvd.matrixU() * rsvd.matrixV().transpose();
+        Eigen::Vector3d t = s * (Kinv * h3);
+        Eigen::Isometry3d pose = Eigen::Isometry3d::Identity();
+        pose.linear() = R;
+        pose.translation() = t;
+        result.c_se3_t.push_back(pose);
+    }
+
+    // Step 5: Initial radial distortion (linear LS)
+    size_t total_obs = 0;
+    for (const auto& v : centered) {
+        total_obs += v.size();
+    }
+    Eigen::MatrixXd A(2 * total_obs, opts.num_radial);
+    Eigen::VectorXd bb(2 * total_obs);
+    size_t row = 0;
+    for (size_t view_idx = 0; view_idx < centered.size(); ++view_idx) {
+        const auto& view = centered[view_idx];
+        const Eigen::Isometry3d& pose = result.c_se3_t[view_idx];
+        for (const auto& ob : view) {
+            Eigen::Vector3d Pw(ob.object_xy.x(), ob.object_xy.y(), 0.0);
+            Eigen::Vector3d Pc = pose * Pw;
+            double x = Pc.x() / Pc.z();
+            double y = Pc.y() / Pc.z();
+            double u = ob.image_uv.x();
+            double v = ob.image_uv.y();
+            double dx = (u - kmtx.cx) / kmtx.fx - x;
+            double dy = (v - kmtx.cy) / kmtx.fy - y;
+            double r2 = x * x + y * y;
+            double rpow = r2;
+            for (int k = 0; k < opts.num_radial; ++k) {
+                A(row, k) = x * rpow;
+                A(row + 1, k) = y * rpow;
+                rpow *= r2;
+            }
+            bb(row) = dx;
+            bb(row + 1) = dy;
+            row += 2;
+        }
+    }
+    Eigen::VectorXd dist = A.bdcSvd(Eigen::ComputeThinU | Eigen::ComputeThinV).solve(bb);
+    Eigen::VectorXd coeffs = Eigen::VectorXd::Zero(opts.num_radial + 2);
+    coeffs.head(opts.num_radial) = dist.head(opts.num_radial);
+
+    result.camera = PinholeCamera<BrownConradyd>(kmtx, coeffs);
+    return result;
+}
 
 }  // namespace calib


### PR DESCRIPTION
## Summary
- add ImageSize, CalibrateIntrinsicsOptions and IntrinsicsResult types
- implement extimate_intrinsics_from_planar to compute homographies, intrinsics, extrinsics and radial distortion

## Testing
- `make test` *(fails: Could not find a package configuration file provided by "Ceres")*


------
https://chatgpt.com/codex/tasks/task_e_68c1a7a231e08332b184087289b1ab1e