### PR TITLE
Add tests for homography pose and intrinsic estimation

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,88 +2,77 @@ include(GoogleTest)
 
 # Test for homography estimation
 add_executable(homography_test homography_test.cpp)
-target_link_libraries(homography_test PRIVATE
-    calibration
-    GTest::gtest_main GTest::gmock_main
-)
+target_link_libraries(homography_test PRIVATE calibration GTest::gtest_main
+                                              GTest::gmock_main)
 gtest_discover_tests(homography_test)
 
 # Test for distortion calculation
 add_executable(distortion_test distortion_test.cpp)
-target_link_libraries(distortion_test PRIVATE
-    calibration
-    GTest::gtest_main GTest::gmock_main
-)
+target_link_libraries(distortion_test PRIVATE calibration GTest::gtest_main
+                                              GTest::gmock_main)
 gtest_discover_tests(distortion_test)
+
+# Test for camera intrinsics estimation (Zhang method)
+add_executable(intrinsics_estimate_test intrinsics_estimate_test.cpp)
+target_link_libraries(intrinsics_estimate_test
+                      PRIVATE calibration GTest::gtest_main GTest::gmock_main)
+gtest_discover_tests(intrinsics_estimate_test)
 
 # Test for camera intrinsics optimization (planar views)
 add_executable(intrinsics_optimize_test intrinsics_optimize_test.cpp)
-target_link_libraries(intrinsics_optimize_test PRIVATE
-    calibration
-    GTest::gtest_main GTest::gmock_main
-)
+target_link_libraries(intrinsics_optimize_test
+                      PRIVATE calibration GTest::gtest_main GTest::gmock_main)
 gtest_discover_tests(intrinsics_optimize_test)
 
 # Test for planar pose estimation
 add_executable(planarpose_test planarpose_test.cpp)
-target_link_libraries(planarpose_test PRIVATE
-    calibration
-    GTest::gtest_main GTest::gmock_main
-)
+target_link_libraries(planarpose_test PRIVATE calibration GTest::gtest_main
+                                              GTest::gmock_main)
 gtest_discover_tests(planarpose_test)
+
+# Test for pose-from-homography decomposition
+add_executable(posefromhomography_test posefromhomography_test.cpp)
+target_link_libraries(posefromhomography_test
+                      PRIVATE calibration GTest::gtest_main GTest::gmock_main)
+gtest_discover_tests(posefromhomography_test)
 
 # Test for extrinsic pose optimization
 add_executable(extrinsics_test extrinsics_test.cpp)
-target_link_libraries(extrinsics_test PRIVATE
-    calibration
-    GTest::gtest_main GTest::gmock_main
-)
+target_link_libraries(extrinsics_test PRIVATE calibration GTest::gtest_main
+                                              GTest::gmock_main)
 gtest_discover_tests(extrinsics_test)
 
 # Test for hand-eye calibration
 add_executable(handeye_test handeye_test.cpp)
-target_link_libraries(handeye_test PRIVATE
-    calibration
-    GTest::gtest_main
-)
+target_link_libraries(handeye_test PRIVATE calibration GTest::gtest_main)
 gtest_discover_tests(handeye_test)
 
 # Test for line scan calibration
 add_executable(linescan_test linescan_test.cpp)
-target_link_libraries(linescan_test PRIVATE
-    calibration
-    GTest::gtest_main GTest::gmock_main
-)
+target_link_libraries(linescan_test PRIVATE calibration GTest::gtest_main
+                                            GTest::gmock_main)
 gtest_discover_tests(linescan_test)
 
 # Test for automatic JSON serialization
 add_executable(json_test json_test.cpp)
-target_link_libraries(json_test PRIVATE
-    calibration
-    GTest::gtest_main GTest::gmock_main
-)
+target_link_libraries(json_test PRIVATE calibration GTest::gtest_main
+                                        GTest::gmock_main)
 gtest_discover_tests(json_test)
 
 # Test for bundle optimisation
 add_executable(bundle_test bundle_test.cpp)
-target_link_libraries(bundle_test PRIVATE
-    calibration
-    GTest::gtest_main GTest::gmock_main
-)
+target_link_libraries(bundle_test PRIVATE calibration GTest::gtest_main
+                                          GTest::gmock_main)
 gtest_discover_tests(bundle_test)
 
 # Test for Scheimpflug camera projection
 add_executable(scheimpflug_test scheimpflug_test.cpp)
-target_link_libraries(scheimpflug_test PRIVATE
-    calibration
-    GTest::gtest_main GTest::gmock_main
-)
+target_link_libraries(scheimpflug_test PRIVATE calibration GTest::gtest_main
+                                               GTest::gmock_main)
 gtest_discover_tests(scheimpflug_test)
 
 # Tests for Scheimpflug hand-eye and bundle adjustment
 add_executable(scheimpflug_bundle_test scheimpflug_bundle_test.cpp)
-target_link_libraries(scheimpflug_bundle_test PRIVATE
-    calibration
-    GTest::gtest_main GTest::gmock_main
-)
+target_link_libraries(scheimpflug_bundle_test
+                      PRIVATE calibration GTest::gtest_main GTest::gmock_main)
 gtest_discover_tests(scheimpflug_bundle_test)

--- a/test/intrinsics_estimate_test.cpp
+++ b/test/intrinsics_estimate_test.cpp
@@ -1,0 +1,78 @@
+#include <gtest/gtest.h>
+
+#include "calib/intrinsics.h"
+#include "utils.h"
+
+using namespace calib;
+
+TEST(EstimateIntrinsics, RecoversCameraMatrix) {
+    RNG rng(10);
+
+    Camera<BrownConradyd> cam_gt;
+    cam_gt.kmtx.fx = 900;
+    cam_gt.kmtx.fy = 920;
+    cam_gt.kmtx.cx = 640;
+    cam_gt.kmtx.cy = 360;
+    cam_gt.kmtx.skew = 0.0;
+    cam_gt.distortion.coeffs = Eigen::VectorXd::Zero(5);
+
+    Eigen::Isometry3d g_se3_c = Eigen::Isometry3d::Identity();
+    Eigen::Isometry3d b_se3_t = Eigen::Translation3d(0.0, 0.0, 2.0) * Eigen::Isometry3d::Identity();
+
+    SimulatedHandEye sim{g_se3_c, b_se3_t, cam_gt};
+    sim.make_sequence(8, rng);
+    sim.make_target_grid(6, 9, 0.03);
+    sim.render_pixels();
+
+    std::vector<PlanarView> views;
+    views.reserve(sim.observations.size());
+    for (const auto& ob : sim.observations) views.push_back(ob.view);
+
+    auto res = estimate_intrinsics(views);
+    ASSERT_TRUE(res.success);
+
+    const auto& K = res.kmtx;
+    const auto& Kg = cam_gt.kmtx;
+    EXPECT_NEAR(K.fx, Kg.fx, 1e-6);
+    EXPECT_NEAR(K.fy, Kg.fy, 1e-6);
+    EXPECT_NEAR(K.cx, Kg.cx, 1e-6);
+    EXPECT_NEAR(K.cy, Kg.cy, 1e-6);
+    EXPECT_NEAR(K.skew, Kg.skew, 1e-9);
+
+    ASSERT_EQ(res.views.size(), views.size());
+    for (size_t i = 0; i < res.views.size(); ++i) {
+        const auto& est = res.views[i].c_se3_t;
+        const auto& gt = sim.c_se3_t[i];
+        bool rot_match =
+            gt.linear().isApprox(est.linear(), 1e-6) || gt.linear().isApprox(-est.linear(), 1e-6);
+        EXPECT_TRUE(rot_match);
+        double cosang = gt.translation().normalized().dot(est.translation().normalized());
+        EXPECT_GT(std::abs(cosang), 0.999);
+    }
+}
+
+TEST(EstimateIntrinsics, FailsWithTooFewViews) {
+    RNG rng(5);
+
+    Camera<BrownConradyd> cam_gt;
+    cam_gt.kmtx.fx = 800;
+    cam_gt.kmtx.fy = 805;
+    cam_gt.kmtx.cx = 320;
+    cam_gt.kmtx.cy = 240;
+    cam_gt.kmtx.skew = 0.0;
+    cam_gt.distortion.coeffs = Eigen::VectorXd::Zero(5);
+
+    Eigen::Isometry3d g_se3_c = Eigen::Isometry3d::Identity();
+    Eigen::Isometry3d b_se3_t = Eigen::Translation3d(0.0, 0.0, 2.0) * Eigen::Isometry3d::Identity();
+
+    SimulatedHandEye sim{g_se3_c, b_se3_t, cam_gt};
+    sim.make_sequence(3, rng);  // fewer than required views
+    sim.make_target_grid(5, 7, 0.04);
+    sim.render_pixels();
+
+    std::vector<PlanarView> views;
+    for (const auto& ob : sim.observations) views.push_back(ob.view);
+
+    auto res = estimate_intrinsics(views);
+    EXPECT_FALSE(res.success);
+}

--- a/test/posefromhomography_test.cpp
+++ b/test/posefromhomography_test.cpp
@@ -1,0 +1,74 @@
+#include "calib/posefromhomography.h"
+
+#include <gtest/gtest.h>
+
+#include <Eigen/Geometry>
+
+using namespace calib;
+
+TEST(PoseFromHomography, RecoversPose) {
+    CameraMatrix K;
+    K.fx = 800;
+    K.fy = 820;
+    K.cx = 320;
+    K.cy = 240;
+    K.skew = 0.0;
+
+    Eigen::Matrix3d R = (Eigen::AngleAxisd(0.2, Eigen::Vector3d::UnitX()) *
+                         Eigen::AngleAxisd(-0.1, Eigen::Vector3d::UnitY()) *
+                         Eigen::AngleAxisd(0.15, Eigen::Vector3d::UnitZ()))
+                            .toRotationMatrix();
+    Eigen::Vector3d t(0.1, -0.2, 3.0);
+
+    Eigen::Matrix3d H;
+    H.col(0) = R.col(0);
+    H.col(1) = R.col(1);
+    H.col(2) = t;
+    H = K.matrix() * H;
+
+    auto res = pose_from_homography(K, H);
+    ASSERT_TRUE(res.success);
+    EXPECT_TRUE(R.isApprox(res.c_se3_t.linear(), 1e-9));
+    EXPECT_TRUE(t.isApprox(res.c_se3_t.translation(), 1e-9));
+    EXPECT_NEAR(res.scale, 1.0, 1e-12);
+    EXPECT_NEAR(res.cond_check, 1.0, 1e-12);
+}
+
+TEST(PoseFromHomography, NegativeZFlipsPose) {
+    CameraMatrix K;
+    K.fx = 500;
+    K.fy = 510;
+    K.cx = 320;
+    K.cy = 240;
+    K.skew = 0.0;
+
+    Eigen::Matrix3d R = (Eigen::AngleAxisd(0.05, Eigen::Vector3d::UnitX()) *
+                         Eigen::AngleAxisd(0.1, Eigen::Vector3d::UnitY()))
+                            .toRotationMatrix();
+    Eigen::Vector3d t(0.2, 0.1, -2.0);  // negative z
+
+    Eigen::Matrix3d H;
+    H.col(0) = R.col(0);
+    H.col(1) = R.col(1);
+    H.col(2) = t;
+    H = K.matrix() * H;
+
+    auto res = pose_from_homography(K, H);
+    ASSERT_TRUE(res.success);
+    EXPECT_GT(res.c_se3_t.translation().z(), 0.0);
+    EXPECT_TRUE((-R).isApprox(res.c_se3_t.linear(), 1e-9));
+    EXPECT_TRUE((-t).isApprox(res.c_se3_t.translation(), 1e-9));
+}
+
+TEST(PoseFromHomography, DegenerateHomographyFails) {
+    CameraMatrix K;
+    K.fx = 400;
+    K.fy = 400;
+    K.cx = 320;
+    K.cy = 240;
+    K.skew = 0.0;
+
+    Eigen::Matrix3d H = Eigen::Matrix3d::Zero();
+    auto res = pose_from_homography(K, H);
+    EXPECT_FALSE(res.success);
+}


### PR DESCRIPTION
## Summary
- add dedicated tests for pose_from_homography, including negative translation and degenerate cases
- add comprehensive tests for Zhang-based estimate_intrinsics function
- register new tests in CMake build

## Testing
- `pre-commit run --files test/CMakeLists.txt test/intrinsics_estimate_test.cpp test/posefromhomography_test.cpp` *(fails: command not found)*
- `pip install pre-commit` *(fails: 403 Forbidden when accessing package repository)*
- `apt-get update` *(fails: repository 403 Forbidden)*
- `cmake -S . -B build` *(fails: could not find CeresConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68c7108e127c83329850002e4ea72b32